### PR TITLE
Updated equipment list with clarified dongle info

### DIFF
--- a/intro/equipment-needed.md
+++ b/intro/equipment-needed.md
@@ -6,7 +6,7 @@ To get started, you'll need:
 
 I started with a [FlightAware Pro Stick Plus](https://www.amazon.com/dp/B07J2RJQ9Z/ref=cm_sw_em_r_mt_dp_U_uwltEbJ8ER2KN). However, eventually you may wish to expand into other areas of SDR. I have moved onto a [KerberosSDR](https://othernet.is/products/kerberossdr-4x-coherent-rtlsdr), which is four RTL-SDRs in one. This lets me dedicate one SDR to ADS-B reception, and three others for things like [AirBand](https://en.wikipedia.org/wiki/Airband), [ACARS](https://app.airframes.io), etc. Note that KerberosSDR has reached EOL and it has been replaced by the [KrakenSDR](https://www.crowdsupply.com/krakenrf/krakensdr) outfitted with 5 SDRs.
 
-If you're just getting started and don't want to spend a lot of cash, a [$20 USB DVB-T RTL2832U dongle](https://www.aliexpress.com/item/32259584047.html) will do the job.
+If you're just getting started and don't want to spend a lot of cash, a [cheap DVB-T RTL2832U WITH R820T2 dongle](https://www.amazon.com/dp/B07K47P7XD) will do the job.
 
 ## An antenna optimised for 1090MHz
 


### PR DESCRIPTION
Updated the dongle name and link with an item that will actually work. The AliExpress one doesn't pick up any flights.
See: https://discussions.flightaware.com/t/only-3-others-positions-detected/49248/2 for more information.

The newly linked one is on Amazon, Prime available, made by AirNav, and more importantly - it works.

---

To add, the Amazon link doesn't contain any referral, tracking, etc..