### PR TITLE
Update blacklist-kernel-modules.md

### DIFF
--- a/setting-up-rtl-sdrs/blacklist-kernel-modules.md
+++ b/setting-up-rtl-sdrs/blacklist-kernel-modules.md
@@ -9,35 +9,42 @@ description: >-
 
 Before we can plug in our RTL-SDR dongle, we need to blacklist the kernel modules for the RTL-SDR USB device from being loaded into the host's kernel and taking ownership of the device.
 
-To do this, create a file `/etc/modprobe.d/blacklist-rtl2832.conf` containing the following:
+To do this, we will create a blacklist file at `/etc/modprobe.d/blacklist-rtlsdr.conf` with the following command. Please copy and paste all lines at once, and press enter after to ensure the final line is given allowing it to run.
 
 ```bash
-sudo nano /etc/modprobe.d/blacklist-rtl2832.conf
-```
 
-```text
-blacklist rtl2832
+sudo tee /etc/modprobe.d/blacklist-rtlsdr.conf > /dev/null <<TEXT1
+# Blacklist host from loading modules for RTL-SDRs to ensure they
+# are left available for the Docker guest.
+blacklist dvb_core
+blacklist dvb_usb_rtl2832u
 blacklist dvb_usb_rtl28xxu
+blacklist dvb_usb_v2
+blacklist r820t
+blacklist rtl2830
+blacklist rtl2832
 blacklist rtl2832_sdr
+blacklist rtl2838
 blacklist rtl8xxxu
+TEXT1
+
 ```
 
-Ensure the modules are unloaded by running the following commands:
+
+Next, ensure the modules are unloaded by running the following commands:
 
 ```bash
-sudo rmmod rtl2832_sdr
-```
-
-```bash
+sudo rmmod dvb_core
+sudo rmmod dvb_usb_rtl2832u
 sudo rmmod dvb_usb_rtl28xxu
-```
-
-```bash
+sudo rmmod dvb_usb_v2
+sudo rmmod r820t
+sudo rmmod rtl2830
 sudo rmmod rtl2832
-```
-
-```bash
+sudo rmmod rtl2832_sdr
+sudo rmmod rtl2838
 sudo rmmod rtl8xxxu
+
 ```
 
 Failure to do the steps above will result in the error below being spammed to the `readsb` container log.


### PR DESCRIPTION
- Update list of RTL-SDR chipsets to blacklist the host from loading, in order to ensure the Docker guest is able to claim them
- Update list of RTL-SDR chipsets to unload from the system if they happened to have been loaded up already onto the host operating system
- Update blacklist file name to be indicate a more purpose based existence and be more chipset agnostic, as multiple device names are contained within this blacklist that holds the purpose of blacklisting RTL-SDR devices; From: `blacklist-rtl2832.conf`  To: `blacklist-rtlsdr.conf`
- Make the creation of blacklist file into a scripted command in order to speed up this step, as well as reduce the possibility of human error
- Note: empty line at bottom of each list is intentional in order to encourage selection of the new empty line when copying and pasting, as this line return would help ensure the final line containing a command is properly submitted in the shell by the user