### PR TITLE
Added clarification about finding RadarBox key when script doesn't output it.

### DIFF
--- a/feeder-containers/feeding-radarbox.md
+++ b/feeder-containers/feeding-radarbox.md
@@ -93,7 +93,40 @@ In the output above, see the line:
 
 As you can see from the output above, the sharing key given to us from Radarbox is `g45643ab345af3c5d5g923a99ffc0de9`.
 
-You should now claim your receiver:
+If the script doesn't output the sharing key, it can be found by using the following command:
+
+```shell
+docker exec -it rbfeeder /bin/sh -c "cat /etc/rbfeeder.ini"
+```
+
+Command output:
+
+```
+[client]
+network_mode=true
+log_file=/var/log/rbfeeder.log
+debug_level=0
+
+lat=40.00
+lon=-111.00
+alt=1420
+
+key=7a0148c894e57464d9757ea666ddcea2
+
+sn=EXTRPI000000
+
+[network]
+mode=beast
+  
+external_port=30005
+external_host=111.11.1.1
+
+[mlat]
+mlat_cmd=/usr/bin/python3 /usr/local/bin/mlat-client --results beast,listen,30105
+autostart_mlat=true
+```
+
+## Claiming Your Receiver
 
 1. Go to [https://www.radarbox.com/](https://www.radarbox.com/)
 2. Create an account or sign in

--- a/feeder-containers/feeding-radarbox.md
+++ b/feeder-containers/feeding-radarbox.md
@@ -96,34 +96,13 @@ As you can see from the output above, the sharing key given to us from Radarbox 
 If the script doesn't output the sharing key, it can be found by using the following command:
 
 ```shell
-docker exec -it rbfeeder /bin/sh -c "cat /etc/rbfeeder.ini"
+docker exec -it rbfeeder /bin/sh -c "cat /etc/rbfeeder.ini" | grep key
 ```
 
 Command output:
 
 ```
-[client]
-network_mode=true
-log_file=/var/log/rbfeeder.log
-debug_level=0
-
-lat=40.00
-lon=-111.00
-alt=1420
-
-key=7a0148c894e57464d9757ea666ddcea2
-
-sn=EXTRPI000000
-
-[network]
-mode=beast
-  
-external_port=30005
-external_host=111.11.1.1
-
-[mlat]
-mlat_cmd=/usr/bin/python3 /usr/local/bin/mlat-client --results beast,listen,30105
-autostart_mlat=true
+key=g45643ab345af3c5d5g923a99ffc0de9
 ```
 
 ## Claiming Your Receiver


### PR DESCRIPTION
Existing script didn't output the key when I ran it. This edit gives people another method of locating the key.

This was my output:
```shell
[rbfeeder] [2023-03-06 11:57:12]  Starting RBFeeder Version 1.0.8 (build 20220708190411)
[rbfeeder] [2023-03-06 11:57:12]  Using configuration file: /etc/rbfeeder.ini
[rbfeeder] [2023-03-06 11:57:12]  Network-mode enabled.
[rbfeeder] [2023-03-06 11:57:12]                Remote host to fetch data: 172.19.0.3
[rbfeeder] [2023-03-06 11:57:12]                Remote port: 30005
[rbfeeder] [2023-03-06 11:57:12]                Remote protocol: BEAST
[rbfeeder] [2023-03-06 11:57:12]  Using GNSS (when available)
[rbfeeder] [2023-03-06 11:57:12]  Start date/time: 2023-03-06 11:57:12
[rbfeeder] [2023-03-06 11:57:12]  Socket for ANRB created. Waiting for connections on port 32088
[rbfeeder] [2023-03-06 11:57:13]  Connection established.
[rbfeeder] [2023-03-06 11:57:13]  Empty sharing key. We will try to create a new one for you!
[rbfeeder] [2023-03-06 11:57:24]  Timeout waiting for new key. Will try again in 30 seconds.
[rbfeeder] [2023-03-06 11:58:24]  Connection established.
[rbfeeder] [2023-03-06 11:58:25]  Connection with RadarBox24 server OK! Key accepted by server.
[rbfeeder] [2023-03-06 11:58:26]  Client type: Raspberry Pi
```