### PR TITLE
Correct Docker volume mounts for influxdb

### DIFF
--- a/useful-extras/alternative-graphing-with-influx-grafana.md
+++ b/useful-extras/alternative-graphing-with-influx-grafana.md
@@ -69,8 +69,8 @@ Append the following lines to the end of the file:
     ports:
       - 8086:8086
     volumes:
-      - influxdb_data:/var/lib/influxdb
-      - influxdb_config:/etc/influxdb
+      - influxdb_data:/var/lib/influxdb2
+      - influxdb_config:/etc/influxdb2
 
   grafana:
     image: grafana/grafana-oss:latest


### PR DESCRIPTION
InfluxDB 2.x is expecting data/config in different paths compared to what is currently documented. https://hub.docker.com/_/influxdb

/var/lib/influxdb
/etc/influxdb

should instead be

/var/lib/influxdb2
/etc/influxdb2

