### PR TITLE
Update gitbook for ultrafeeder changes and usability

### DIFF
--- a/feeder-containers/feeding-ads-b-exchange.md
+++ b/feeder-containers/feeding-ads-b-exchange.md
@@ -25,7 +25,7 @@ Open the `docker-compose.yml` and make the following environment value is part o
 
 ## Refresh running containers
 
-Once the file has been updated, issue the command `docker compose up -d` in the application directory to apply the changes to the `ultrafeeder` container. 
+Once the file has been updated, issue the command `docker compose up -d` in the application directory to apply the changes to the `ultrafeeder` container.
 
 After a few minutes, point your browser at [https://adsbexchange.com/myip/](https://adsbexchange.com/myip/). You should see green smiley faces indicating that you are successfully sending data.
 Also check if your MLAT is synchronized: <https://map.adsbexchange.com/mlat-map/>

--- a/feeder-containers/feeding-ads-b-exchange.md
+++ b/feeder-containers/feeding-ads-b-exchange.md
@@ -9,141 +9,23 @@ description: 'If you wish to feed ADS-B Exchange, follow the steps below.'
 * <https://www.rtl-sdr.com/ads-b-exchange-acquired-by-private-firm-jetnet/>
 * <https://www.jetnet.com/news/jetnet-acquires-ads-b-exchange.html>
 
-The docker image [`ghcr.io/sdr-enthusiasts/docker-adsbexchange`](https://github.com/sdr-enthusiasts/docker-adsbexchange) contains the ADS-B Exchange feeder software and all of its required prerequisites and libraries. This needs to run in conjunction with `ultrafeeder` \(or another Beast provider\).
 
-## Generating a UUID
+## Update `ultrafeeder` container configuration
 
-If you are new to feeding ADS-B Exchange, you will need to generate a UUID for your feeder. If you already have a UUID from an existing feeder that you wish to re-use, you can skip this step.
+Before running `docker compose`, we also want to update the configuration of the `ultrafeeder` container, so that it generates MLAT data for piaware.
 
-In order to generate a feeder UUID, run the following command:
-
-```bash
-cat /proc/sys/kernel/random/uuid
-```
-
-Take note of the UUID returned.
-
-## Update `.env` file
-
-Inside your application directory \(`/opt/adsb`\), edit the `.env` file using your favourite text editor. Beginners may find the editor `nano` easy to use:
-
-```bash
-nano /opt/adsb/.env
-```
-
-This file holds all of the commonly used variables \(such as our latitude, longitude and altitude\). We're going to add our ADS-B Exchange variables to this file. Add the following lines to the file:
-
-```text
-ADSBX_UUID=YOURUUID
-ADSBX_SITENAME=YOURSITENAME
-```
-
-* Replace `YOURSITENAME` with a unique name for your receiver, using only the characters "A-Z", "a-z", \(`-`\) and \(`_`\), and ending in a random number.
-* Replace `YOURUUID` with the UUID that was generated in the previous step.
-
-For example:
-
-```text
-ADSBX_UUID=4e8413e6-52eb-11ea-8681-1c1b0d925d3g
-ADSBX_SITENAME=johnsmith_123
-```
-
-## Deploying ADS-B Exchange feeder
-
-Open the `docker-compose.yml` file that was created when deploying `ultrafeeder`.
-
-Append the following lines to the end of the file \(inside the `services:` section\):
+Open the `docker-compose.yml` and make the following environment value is part of the `ULTRAFEEDER_CONFIG` variable to the `ultrafeeder` service:
 
 ```yaml
-  adsbx:
-    image: ghcr.io/sdr-enthusiasts/docker-adsbexchange:latest
-    tty: true
-    container_name: adsbx
-    restart: always
-    environment:
-      - BEASTHOST=ultrafeeder
-      - LAT=${FEEDER_LAT}
-      - LONG=${FEEDER_LONG}
-      - ALT=${FEEDER_ALT_M}m
-      - SITENAME=${ADSBX_SITENAME}
-      - UUID=${ADSBX_UUID}
-      - TZ=${FEEDER_TZ}
-    tmpfs:
-      - /run:exec,size=64M,uid=1000,gid=1000
-      - /var/log
+      - ULTRAFEEDER_CONFIG=
+          adsb,feed1.adsbexchange.com,30004,beast_reduce_plus_out;
+          mlat,feed.adsbexchange.com,31090,39005;
 ```
 
-To explain what's going on in this addition:
 
-* We're creating a container called `adsbx`, from the image `ghcr.io/sdr-enthusiasts/docker-adsbexchange:latest`.
-* We're passing several environment variables to the container:
-  * `BEASTHOST=ultrafeeder` to inform the feeder to get its ADSB data from the container `ultrafeeder` over our private `adsbnet` network.
-  * `LAT` will use the `FEEDER_LAT` variable from your `.env` file.
-  * `LONG` will use the `FEEDER_LONG` variable from your `.env` file.
-  * `ALT` will use the `FEEDER_ALT_M` variable from your `.env` file.
-  * `SITENAME` will use the `ADSBX_SITENAME` variable from your `.env` file.
-  * `UUID` will use the `ADSBX_UUID` variable from your `.env` file.
-  * `TZ` will use the `FEEDER_TZ` variable from your `.env` file.
-* We're using `tmpfs` for volumes that have regular I/O. Any files stored in a `tmpfs` mount are temporarily stored outside the container's writable layer. This helps to reduce:
-  * The size of the container, by not writing changes to the underlying container; and
-  * SD Card or SSD wear
+## Refresh running containers
 
-Once the file has been updated, issue the command `docker compose up -d` in the application directory to apply the changes and bring up the `adsbx` container. You should see the following output:
-
-```text
-ultrafeeder is up-to-date
-Creating adsbx
-```
-
-You can see from the output above that the `ultrafeeder` container was left alone \(as the configuration for this container did not change\), and a new container `adsbx` was created.
-
-We can view the logs for the environment with the command `docker compose logs`, or continually "tail" them with `docker compose logs -f`. We should now see logs from our newly created `adsbx` container:
-
-```text
-adsbx             | [s6-init] making user provided files available at /var/run/s6/etc...exited 0.
-adsbx             | [s6-init] ensuring user provided files have correct perms...exited 0.
-adsbx             | [fix-attrs.d] applying ownership & permissions fixes...
-adsbx             | [fix-attrs.d] done.
-adsbx             | [cont-init.d] executing container initialization scripts...
-adsbx             | [cont-init.d] 01-adsbexchange: executing...
-adsbx             | Statistics available at: https://www.adsbexchange.com/api/feeders/?feed=4e8413e6-52eb-11ea-8681-1c1b0d925d3g
-adsbx             | [cont-init.d] 01-adsbexchange: exited 0.
-adsbx             | [cont-init.d] done.
-adsbx             | [services.d] starting services
-adsbx             | [services.d] done.
-adsbx             | [adsbexchange-feed] Fri Nov 20 14:48:27 2020 AWST  readsb starting up.
-adsbx             | [adsbexchange-feed] readsb version: wiedehopf git: 9f533868 (cpr focus json_reliable fast track, Sun Oct 18 18:26:34 2020 0200)
-adsbx             | [adsbexchange-feed] struct sizes: 1552, 24, 64, 100
-adsbx             | [adsbexchange-stats] Found local resolver in resolv.conf, disabling DNS Cache
-adsbx             | [adsbexchange-stats] Using UUID [4e8413e6-52eb-11ea-8681-1c1b0d925d3g] for stats uploads
-adsbx             | [adsbexchange-stats] Using JSON directory [/run/adsbexchange-feed] for source data
-adsbx             | [adsbexchange-stats] NOT using script's DNS cache
-adsbx             | [mlat-client] mlat-client 0.3.1 starting up
-adsbx             | [mlat-client] Listening for Beast-format results connection on port 30105
-adsbx             | [mlat-client] Connecting to feed.adsbexchange.com:31090
-adsbx             | [adsbexchange-feed] Beast TCP input: Connection established: readsb (172.30.0.12) port 30005
-adsbx             | [mlat-client] Connected to multilateration server at feed.adsbexchange.com:31090, handshaking
-adsbx             | [adsbexchange-feed] BeastReduce TCP output: Connection established: feed.adsbexchange.com (216.48.109.64) port 30004
-adsbx             | [adsbexchange-feed] UUID: 4e8413e6-52eb-11ea-8681-1c1b0d925d3g
-adsbx             | [mlat-client] Beast-format results connection with 172.30.0.12:30005: connection established
-adsbx             | [mlat-client] Server says:
-adsbx             | [mlat-client]
-adsbx             | [mlat-client]         In-development v2 server. Expect odd behaviour.
-adsbx             | [mlat-client]
-adsbx             | [mlat-client]         The multilateration server source code is available under
-adsbx             | [mlat-client]         the terms of the Affero GPL (v3 or later). You may obtain
-adsbx             | [mlat-client]         a copy of this server's source code at the following
-adsbx             | [mlat-client]         location: https://github.com/adsbexchange/mlat-server
-adsbx             | [mlat-client]
-adsbx             | [mlat-client] Handshake complete.
-adsbx             | [mlat-client]   Compression:       zlib2
-adsbx             | [mlat-client]   UDP transport:     disabled
-adsbx             | [mlat-client]   Split sync:        disabled
-adsbx             | [mlat-client] Connecting to readsb:30005
-adsbx             | [mlat-client] Input connected to readsb:30005
-adsbx             | [mlat-client] Input format changed to BEAST, 12MHz clock
-adsbx             | [mlat-client] Accepted Beast-format results connection from ::ffff:172.30.0.11:53198
-```
+Once the file has been updated, issue the command `docker compose up -d` in the application directory to apply the changes to the `ultrafeeder` container. 
 
 After a few minutes, point your browser at [https://adsbexchange.com/myip/](https://adsbexchange.com/myip/). You should see green smiley faces indicating that you are successfully sending data.
 Also check if your MLAT is synchronized: <https://map.adsbexchange.com/mlat-map/>

--- a/feeder-containers/feeding-adsbhub.md
+++ b/feeder-containers/feeding-adsbhub.md
@@ -77,7 +77,6 @@ Once the file has been updated, issue the command `docker compose up -d` in the 
 
 ```text
 ultrafeeder is up-to-date
-adsbx is up-to-date
 piaware is up-to-date
 fr24 is up-to-date
 pfclient is up-to-date

--- a/feeder-containers/feeding-flightaware-piaware.md
+++ b/feeder-containers/feeding-flightaware-piaware.md
@@ -129,11 +129,24 @@ To explain what's going on in this addition:
   * The size of the container, by not writing changes to the underlying container; and
   * SD Card or SSD wear
 
+## Update `ultrafeeder` container configuration
+
+Before running `docker compose`, we also want to update the configuration of the `ultrafeeder` container, so that it generates MLAT data for piaware.
+
+Open the `docker-compose.yml` and make the following environment value is part of the `ULTRAFEEDER_CONFIG` variable to the `ultrafeeder` service:
+
+```yaml
+      - ULTRAFEEDER_CONFIG=mlathub,piaware,30105,beast_in;
+```
+
+To explain this addition, the `ultrafeeder` container will connect to the `piaware` container on port `30105` and receive MLAT data. This data will then be included in any outbound data streams from `ultrafeeder`.
+
+## Refresh running containers
+
 Once the file has been updated, issue the command `docker compose up -d` in the application directory to apply the changes and bring up the `piaware` container. You should see the following output:
 
 ```text
 ultrafeeder is up-to-date
-adsbx is up-to-date
 Creating piaware
 ```
 

--- a/feeder-containers/feeding-flightradar24.md
+++ b/feeder-containers/feeding-flightradar24.md
@@ -125,7 +125,6 @@ Once the file has been updated, issue the command `docker compose up -d` in the 
 
 ```text
 ultrafeeder is up-to-date
-adsbx is up-to-date
 piaware is up-to-date
 Creating fr24
 ```

--- a/feeder-containers/feeding-opensky-network.md
+++ b/feeder-containers/feeding-opensky-network.md
@@ -170,7 +170,6 @@ Once the file has been updated, issue the command `docker compose up -d` in the 
 
 ```text
 ultrafeeder is up-to-date
-adsbx is up-to-date
 piaware is up-to-date
 fr24 is up-to-date
 pfclient is up-to-date

--- a/feeder-containers/feeding-planefinder.md
+++ b/feeder-containers/feeding-planefinder.md
@@ -119,7 +119,6 @@ Once the file has been updated, issue the command `docker compose up -d` in the 
 
 ```text
 ultrafeeder is up-to-date
-adsbx is up-to-date
 piaware is up-to-date
 fr24 is up-to-date
 Creating pfclient

--- a/feeder-containers/feeding-radarbox.md
+++ b/feeder-containers/feeding-radarbox.md
@@ -181,11 +181,24 @@ To explain what's going on in this addition:
   * The size of the container, by not writing changes to the underlying container; and
   * SD Card or SSD wear
 
+## Update `ultrafeeder` container configuration
+
+Before running `docker compose`, we also want to update the configuration of the `ultrafeeder` container, so that it generates MLAT data for piaware.
+
+Open the `docker-compose.yml` and make the following environment value is part of the `ULTRAFEEDER_CONFIG` variable to the `ultrafeeder` service:
+
+```yaml
+      - ULTRAFEEDER_CONFIG=mlathub,rbfeeder,30105,beast_in;
+```
+
+To explain this addition, the `ultrafeeder` container will connect to the `rbfeeder` container on port `30105` and receive MLAT data. This data will then be included in any outbound data streams from `ultrafeeder`.
+
+## Refresh running containers
+
 Once the file has been updated, issue the command `docker compose up -d` in the application directory to apply the changes and bring up the `rbfeeder` container. You should see the following output:
 
 ```text
 ultrafeeder is up-to-date
-adsbx is up-to-date
 piaware is up-to-date
 fr24 is up-to-date
 Creating rbfeeder

--- a/feeder-containers/feeding-radarvirtuel.md
+++ b/feeder-containers/feeding-radarvirtuel.md
@@ -82,11 +82,24 @@ To explain what's going on in this addition:
   * Enabling receiving MLAT RAW data and sending latitude, longitude and altitude from the .env file
 * The mounted volumes make sure that the container will use the same timezone as your host system
 
+## Update `ultrafeeder` container configuration
+
+Before running `docker compose`, we also want to update the configuration of the `ultrafeeder` container, so that it generates MLAT data for piaware.
+
+Open the `docker-compose.yml` and make the following environment value is part of the `ULTRAFEEDER_CONFIG` variable to the `ultrafeeder` service:
+
+```yaml
+      - ULTRAFEEDER_CONFIG=mlathub,radarvirtuel,30105,beast_in;
+```
+
+To explain this addition, the `ultrafeeder` container will connect to the `radarvirtuel` container on port `30105` and receive MLAT data. This data will then be included in any outbound data streams from `ultrafeeder`.
+
+## Refresh running containers
+
 Once the file has been updated, issue the command `docker compose pull radarvirtuel && docker compose up -d` in the application directory to apply the changes and bring up the `radarvirtuel` container. You should see the following output:
 
 ```text
 ultrafeeder is up-to-date
-adsbx is up-to-date
 piaware is up-to-date
 fr24 is up-to-date
 pfclient is up-to-date

--- a/foundations/deploy-dump978-usa-only.md
+++ b/foundations/deploy-dump978-usa-only.md
@@ -105,6 +105,15 @@ Open the `docker-compose.yml` and make the following environment value is part o
       - ULTRAFEEDER_CONFIG=adsb,dump978,30978,uat_in;
 ```
 
+
+In addition, add these lines in the `GRAPHS1090` section of the `ultrafeeder` service:
+
+```yaml
+      # GRAPHS1090 (Decoder and System Status Web Page) parameters:
+      - ENABLE_978=yes
+      - URL_978=http://dump978/skyaware978
+```
+
 To explain this addition, the `ultrafeeder` container will connect to the `dump978` container on port `30978` and receive UAT data. This UAT data will then be included in any outbound data streams from `ultrafeeder`.
 
 ## Refresh running containers

--- a/foundations/deploy-dump978-usa-only.md
+++ b/foundations/deploy-dump978-usa-only.md
@@ -41,7 +41,7 @@ UAT_SDR_PPM=<your PPM from the step above>
 
 * `UAR_SDR_SERIAL` is set to the serial number for your ADS-B dongle; the previous serialization steps set this to 978 by default but if you have used a different serial number enter it here
 * `UAT_SDR_GAIN` is set to your desired dongle gain in dB, or `autogain` if you would like the software to determine the optimal gain
-* `UAT_SDR_PPM` is set to your desired dongle PPM setting. Enter the number from the PPM estimation step earlier on this page. 
+* `UAT_SDR_PPM` is set to your desired dongle PPM setting. Enter the number from the PPM estimation step earlier on this page.
 
 For example:
 

--- a/foundations/deploy-dump978-usa-only.md
+++ b/foundations/deploy-dump978-usa-only.md
@@ -13,6 +13,47 @@ The FAA has adopted 1090MHz for all flight levels, and UAT only for operations b
 
 **If you live outside of the USA \(or only have one SDR\), you can skip this section!**
 
+## Identify your UAT dongle's optimal PPM
+
+Every RTL-SDR dongle will have a small frequency error as it is cheaply mass produced and not tested for accuracy. This frequency error is linear across the spectrum, and can be adjusted in most SDR programs by entering a PPM (parts per million) offset value. This  allows you to adjust the PPM figure using the ADSB_SDR_PPM environment variable.
+
+Unplug all SDRs, leaving only the SDR to be used for 978MHz reception plugged in. Issue the following command:
+
+`docker run --rm -it --entrypoint /scripts/estimate_rtlsdr_ppm.sh --device /dev/bus/usb ghcr.io/sdr-enthusiasts/docker-readsb-protobuf:latest`
+
+This takes about 30 minutes and will print a numerical value for Estimated optimum PPM setting.
+
+## Update the .env file for UAT
+
+Inside your application directory \(`/opt/adsb`\), edit the `.env` file using your favourite text editor. Beginners may find the editor `nano` easy to use:
+
+```bash
+nano /opt/adsb/.env
+```
+
+This file holds all of the commonly used variables \(such as our latitude, longitude and altitude\). We're going to add more variables associated with UAT dongles.
+
+```text
+UAT_SDR_SERIAL=978
+UAT_SDR_GAIN=<your desired gain>
+UAT_SDR_PPM=<your desired PPM>
+```
+
+* `UAR_SDR_SERIAL` is set to the serial number for your ADS-B dongle; the previous serialization steps set this to 978 by default but if you have used a different serial number enter it here
+* `UAT_SDR_GAIN` is set to your desired dongle gain in dB, or `autogain` if you would like the software to determine the optimal gain
+* `UAT_SDR_PPM` is set to your desired dongle PPM setting. Enter the number from the PPM estimation step earlier on this page. 
+
+For example:
+
+```text
+UAT_SDR_SERIAL=978
+UAT_SDR_GAIN=autogain
+UAT_SDR_PPM=1
+```
+
+
+
+
 ## Deploying `dump978` container
 
 Open the `docker-compose.yml` file that was created when deploying `ultrafeeder`.
@@ -56,7 +97,7 @@ To explain what's going on in this addition:
 
 ## Update `ultrafeeder` container configuration
 
-Before running `docker compose`, we also want to update the configuration of the `readsb` container, so that it pulls the demodulated UAT data from the `dump978` container.
+Before running `docker compose`, we also want to update the configuration of the `ultrafeeder` container, so that it pulls the demodulated UAT data from the `dump978` container.
 
 Open the `docker-compose.yml` and make the following environment value is part of the `ULTRAFEEDER_CONFIG` variable to the `ultrafeeder` service:
 

--- a/foundations/deploy-dump978-usa-only.md
+++ b/foundations/deploy-dump978-usa-only.md
@@ -36,7 +36,7 @@ This file holds all of the commonly used variables \(such as our latitude, longi
 ```text
 UAT_SDR_SERIAL=978
 UAT_SDR_GAIN=<your desired gain>
-UAT_SDR_PPM=<your desired PPM>
+UAT_SDR_PPM=<your PPM from the step above>
 ```
 
 * `UAR_SDR_SERIAL` is set to the serial number for your ADS-B dongle; the previous serialization steps set this to 978 by default but if you have used a different serial number enter it here

--- a/foundations/deploy-ultrafeeder-container.md
+++ b/foundations/deploy-ultrafeeder-container.md
@@ -99,7 +99,7 @@ services:
       # --------------------------------------------------
       # GRAPHS1090 (Decoder and System Status Web Page) parameters:
       - GRAPHS1090_DARKMODE=true
-      # 
+      #
       # --------------------------------------------------
     volumes:
       - /opt/adsb/ultrafeeder/globe_history:/var/globe_history
@@ -152,9 +152,9 @@ We can view the logs for the environment with the command `docker compose logs`,
 [fix-attrs.d] applying ownership & permissions fixes...
 [fix-attrs.d] done.
 [cont-init.d] executing container initialization scripts...
-[cont-init.d] 00-libsecomp2: executing... 
+[cont-init.d] 00-libsecomp2: executing...
 [cont-init.d] 00-libsecomp2: exited 0.
-[cont-init.d] 01-print-container-version: executing... 
+[cont-init.d] 01-print-container-version: executing...
 [2023-05-08 13:15:51.203][01-print-container-version] Container Version: 20230505-190743_9e4ed76_main, build date 2023-05-05 15:07:43 -0400
 [cont-init.d] 01-print-container-version: exited 0.
 ... (more logs here)

--- a/foundations/deploy-ultrafeeder-container.md
+++ b/foundations/deploy-ultrafeeder-container.md
@@ -189,11 +189,11 @@ NETWORK ID     NAME           DRIVER    SCOPE
 
 If configured and started using the example above, the container will make a website available at port 8080 of your host machine. Here are a few web pages that are generated (replace `my_host_ip` with the name or IP address of your host machine):
 
-* http://my_host_ip:8080/ : `tar1090` map and table of all aircraft received
-* http://my_host_ip:8080/graphs1090 : page with graphs and operations statistics of your station
-* http://my_host_ip:8080?pTracks : showing all aircraft tracks received in the last 24 hours
-* http://my_host_ip:8080?heatmap&realheat : showing a heatmap of all aircrafts of the last 24 hours
-* http://my_host_ip:8080?replay : showing a timelapse replay of the past few days
+* `http://my_host_ip:8080/` : `tar1090` map and table of all aircraft received
+* `http://my_host_ip:8080/graphs1090` : page with graphs and operations statistics of your station
+* `http://my_host_ip:8080?pTracks` : showing all aircraft tracks received in the last 24 hours
+* `http://my_host_ip:8080?heatmap&realheat` : showing a heatmap of all aircrafts of the last 24 hours
+* `http://my_host_ip:8080?replay` : showing a timelapse replay of the past few days
 
 ## Viewing Live Data in Text Format
 

--- a/foundations/deploy-ultrafeeder-container.md
+++ b/foundations/deploy-ultrafeeder-container.md
@@ -98,10 +98,7 @@ services:
       #
       # --------------------------------------------------
       # GRAPHS1090 (Decoder and System Status Web Page) parameters:
-      # The two 978 related parameters should only be included if you are running dump978 for UAT reception (USA only)
       - GRAPHS1090_DARKMODE=true
-      # - ENABLE_978=yes
-      # - URL_978=http://dump978/skyaware978
       # 
       # --------------------------------------------------
     volumes:

--- a/foundations/prepare-the-project-environment.md
+++ b/foundations/prepare-the-project-environment.md
@@ -37,7 +37,7 @@ This takes about 30 minutes and will print a numerical value for Estimated optim
 
 ## Create a heywhatsthat Panorama ID
 
-Heywhatsthat is a website that can generate an overlay on your map that will show the theoretical range of your location based on obstacles and the curvature of the earth. Follow step 1 at the instructions [here](https://github.com/wiedehopf/tar1090#heywhatsthatcom-range-outline) to generate a panorama for your feeder's location and altitude. In the upper left of the panorma page there will be a URL that will look like this: https://www.heywhatsthat.com/?view=NC3XJWK1. That code will be used later in the setup instructions.
+Heywhatsthat is a website that can generate an overlay on your map that will show the theoretical range of your location based on obstacles and the curvature of the earth. Follow step 1 at the instructions [here](https://github.com/wiedehopf/tar1090#heywhatsthatcom-range-outline) to generate a panorama for your feeder's location and altitude. In the upper left of the panorma page there will be a URL that will look like this: https://www.heywhatsthat.com/?view=NN3NNNN1. That code will be used later in the setup instructions.
 
 ## Create a `.env` file to hold our environment's variables
 

--- a/foundations/prepare-the-project-environment.md
+++ b/foundations/prepare-the-project-environment.md
@@ -35,6 +35,10 @@ Unplug all SDRs, leaving only the SDR to be used for 1090MHz reception plugged i
 
 This takes about 30 minutes and will print a numerical value for Estimated optimum PPM setting.
 
+## Create a heywhatsthat Panorama ID
+
+Heywhatsthat is a website that can generate an overlay on your map that will show the theoretical range of your location based on obstacles and the curvature of the earth. Follow step 1 at the instructions [here](https://github.com/wiedehopf/tar1090#heywhatsthatcom-range-outline) to generate a panorama for your feeder's location and altitude. In the upper left of the panorma page there will be a URL that will look like this: https://www.heywhatsthat.com/?view=NC3XJWK1. That code will be used later in the setup instructions.
+
 ## Create a `.env` file to hold our environment's variables
 
 Inside this directory, create a file named `.env` using your favourite text editor. Beginners may find the editor `nano` easy to use:
@@ -51,10 +55,14 @@ FEEDER_ALT_M=<your antenna's altitude in metres>
 FEEDER_LAT=<your latitude>
 FEEDER_LONG=<your longitude>
 FEEDER_TZ=<your timezone>
+FEEDER_NAME=<your location name>
 ADSB_SDR_SERIAL=1090
 ADSB_SDR_GAIN=<your desired gain>
 ADSB_SDR_PPM=<your PPM from the step above>
-UUID=<your UUID from the step above>
+ULTRAFEEDER_UUID=<your UUID from the step above>
+FEEDER_HEYWHATSTHAT_ID=<your heywhatsthat ID from the step above>
+FEEDER_HEYWHATSTHAT_ALTS=<desired theoretical range altitudes>
+
 ```
 
 ...where:
@@ -64,10 +72,13 @@ UUID=<your UUID from the step above>
 * `FEEDER_LAT` is set to your antenna's latitude (also available at link above)
 * `FEEDER_LONG` is set to your antenna's longitude (also available at link above)
 * `FEEDER_TZ` is set to your timezone, in ["TZ database name" format](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+* `FEEDER_NAME` is set to a location name. This is only used in the title of the map's web page.
 * `ADSB_SDR_SERIAL` is set to the serial number for your ADS-B dongle; the previous steps set this to 1090 by default but if you have used a different serial number enter it here
 * `ADSB_SDR_GAIN` is set to your desired dongle gain in dB, or `autogain` if you would like the software to determine the optimal gain
 * `ADSB_SDR_PPM` is set to your desired dongle PPM setting. Enter the number from the PPM estimation step earlier on this page. 
-* `UUID` is set to the UUID you generated above
+* `ULTRAFEEDER_UUID` is set to the UUID you generated above
+* `FEEDER_HEYWHATSTHAT_ID` is set to the code in the URL generated above
+* `FEEDER_HEYWHATSTHAT_ALTS` is a comma delimited list of altitudes in meters for which the map will display a theoretical maximum range; a common starting position is 3000 meters and 12000 meters
 
 For example:
 
@@ -80,7 +91,9 @@ FEEDER_TZ=Australia/Perth
 ADSB_SDR_SERIAL=1090
 ADSB_SDR_GAIN=autogain
 ADSB_SDR_PPM=1
-UUID=00000000-0000-0000-0000-000000000000
+ULTRAFEEDER_UUID=00000000-0000-0000-0000-000000000000
+FEEDER_HEYWHATSTHAT_ID=NN3NNNN1
+FEEDER_HEYWHATSTHAT_ALTS=3000,12000
 ```
 
 **Note for beginners:** If you run an `ls` command in that directory, you won't see your `.env` file. Files beginning with a period are treated as hidden files. To see the file, you can run `ls -a` \(`-a` for all files\).

--- a/foundations/prepare-the-project-environment.md
+++ b/foundations/prepare-the-project-environment.md
@@ -29,7 +29,7 @@ You can use the output string of this command (in format of `00000000-0000-0000-
 
 Every RTL-SDR dongle will have a small frequency error as it is cheaply mass produced and not tested for accuracy. This frequency error is linear across the spectrum, and can be adjusted in most SDR programs by entering a PPM (parts per million) offset value. This  allows you to adjust the PPM figure using the ADSB_SDR_PPM environment variable.
 
-Unplug all SDRs, leaving only the SDR to be used for 978MHz reception plugged in. Issue the following command:
+Unplug all SDRs, leaving only the SDR to be used for 1090MHz reception plugged in. Issue the following command:
 
 `docker run --rm -it --entrypoint /scripts/estimate_rtlsdr_ppm.sh --device /dev/bus/usb ghcr.io/sdr-enthusiasts/docker-readsb-protobuf:latest`
 

--- a/foundations/prepare-the-project-environment.md
+++ b/foundations/prepare-the-project-environment.md
@@ -37,7 +37,7 @@ This takes about 30 minutes and will print a numerical value for Estimated optim
 
 ## Create a heywhatsthat Panorama ID
 
-Heywhatsthat is a website that can generate an overlay on your map that will show the theoretical range of your location based on obstacles and the curvature of the earth. Follow step 1 at the instructions [here](https://github.com/wiedehopf/tar1090#heywhatsthatcom-range-outline) to generate a panorama for your feeder's location and altitude. In the upper left of the panorma page there will be a URL that will look like this: `https://www.heywhatsthat.com/?view=NN3NNNN1`. That code will be used later in the setup instructions.
+Heywhatsthat is a website that can generate an overlay on your map that will show the theoretical range of your location based on obstacles and the curvature of the earth. Follow step 1 at the instructions [here](https://github.com/wiedehopf/tar1090#heywhatsthatcom-range-outline) to generate a panorama for your feeder's location and altitude. In the upper left of the panorama page there will be a URL that will look like this: `https://www.heywhatsthat.com/?view=NN3NNNN1`. That code will be used later in the setup instructions.
 
 ## Create a `.env` file to hold our environment's variables
 

--- a/foundations/prepare-the-project-environment.md
+++ b/foundations/prepare-the-project-environment.md
@@ -75,7 +75,7 @@ FEEDER_HEYWHATSTHAT_ALTS=<desired theoretical range altitudes>
 * `FEEDER_NAME` is set to a location name. This is only used in the title of the map's web page.
 * `ADSB_SDR_SERIAL` is set to the serial number for your ADS-B dongle; the previous steps set this to 1090 by default but if you have used a different serial number enter it here
 * `ADSB_SDR_GAIN` is set to your desired dongle gain in dB, or `autogain` if you would like the software to determine the optimal gain
-* `ADSB_SDR_PPM` is set to your desired dongle PPM setting. Enter the number from the PPM estimation step earlier on this page. 
+* `ADSB_SDR_PPM` is set to your desired dongle PPM setting. Enter the number from the PPM estimation step earlier on this page.
 * `ULTRAFEEDER_UUID` is set to the UUID you generated above
 * `FEEDER_HEYWHATSTHAT_ID` is set to the code in the URL generated above
 * `FEEDER_HEYWHATSTHAT_ALTS` is a comma delimited list of altitudes in meters for which the map will display a theoretical maximum range; a common starting position is 3000 meters and 12000 meters

--- a/foundations/prepare-the-project-environment.md
+++ b/foundations/prepare-the-project-environment.md
@@ -15,6 +15,26 @@ sudo mkdir -p -m 777 /opt/adsb
 cd /opt/adsb
 ```
 
+## Generate a UUID
+
+A UUID is a unique identifier that will identify you to various feeding servers. If you already have a `UUID` that was generated for the ADSBExchange service, feel free to reuse that one. If you don't have one, you can generate one by logging onto you Linux machine (Raspberry Pi, etc.) and giving this command:
+
+```bash
+cat  /proc/sys/kernel/random/uuid
+```
+
+You can use the output string of this command (in format of `00000000-0000-0000-0000-000000000000`) as your UUID. Please use the same UUID consistently for each feeder of your station.
+
+## Identify your ADS-B dongle's optimal PPM
+
+Every RTL-SDR dongle will have a small frequency error as it is cheaply mass produced and not tested for accuracy. This frequency error is linear across the spectrum, and can be adjusted in most SDR programs by entering a PPM (parts per million) offset value. This  allows you to adjust the PPM figure using the ADSB_SDR_PPM environment variable.
+
+Unplug all SDRs, leaving only the SDR to be used for 978MHz reception plugged in. Issue the following command:
+
+`docker run --rm -it --entrypoint /scripts/estimate_rtlsdr_ppm.sh --device /dev/bus/usb ghcr.io/sdr-enthusiasts/docker-readsb-protobuf:latest`
+
+This takes about 30 minutes and will print a numerical value for Estimated optimum PPM setting.
+
 ## Create a `.env` file to hold our environment's variables
 
 Inside this directory, create a file named `.env` using your favourite text editor. Beginners may find the editor `nano` easy to use:
@@ -31,6 +51,10 @@ FEEDER_ALT_M=<your antenna's altitude in metres>
 FEEDER_LAT=<your latitude>
 FEEDER_LONG=<your longitude>
 FEEDER_TZ=<your timezone>
+ADSB_SDR_SERIAL=1090
+ADSB_SDR_GAIN=<your desired gain>
+ADSB_SDR_PPM=<your desired PPM>
+ULTRAFEEDER=<your UUID from the step above>
 ```
 
 ...where:
@@ -40,6 +64,10 @@ FEEDER_TZ=<your timezone>
 * `FEEDER_LAT` is set to your antenna's latitude (also available at link above)
 * `FEEDER_LONG` is set to your antenna's longitude (also available at link above)
 * `FEEDER_TZ` is set to your timezone, in ["TZ database name" format](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+* `ADSB_SDR_SERIAL` is set to the serial number for your ADS-B dongle; the previous steps set this to 1090 by default but if you have used a different serial number enter it here
+* `ADSB_SDR_GAIN` is set to your desired dongle gain in dB, or `autogain` if you would like the software to determine the optimal gain
+* `ADSB_SDR_PPM` is set to your desired dongle PPM setting. Enter the number from the PPM estimation step earlier on this page. 
+* `UUID` is set to the UUID you generated above
 
 For example:
 
@@ -49,6 +77,10 @@ FEEDER_ALT_M=31.5
 FEEDER_LAT=-31.9505
 FEEDER_LONG=115.8605
 FEEDER_TZ=Australia/Perth
+ADSB_SDR_SERIAL=1090
+ADSB_SDR_GAIN=autogain
+ADSB_SDR_PPM=1
+UUID=00000000-0000-0000-0000-000000000000
 ```
 
 **Note for beginners:** If you run an `ls` command in that directory, you won't see your `.env` file. Files beginning with a period are treated as hidden files. To see the file, you can run `ls -a` \(`-a` for all files\).

--- a/foundations/prepare-the-project-environment.md
+++ b/foundations/prepare-the-project-environment.md
@@ -53,8 +53,8 @@ FEEDER_LONG=<your longitude>
 FEEDER_TZ=<your timezone>
 ADSB_SDR_SERIAL=1090
 ADSB_SDR_GAIN=<your desired gain>
-ADSB_SDR_PPM=<your desired PPM>
-ULTRAFEEDER=<your UUID from the step above>
+ADSB_SDR_PPM=<your PPM from the step above>
+UUID=<your UUID from the step above>
 ```
 
 ...where:

--- a/foundations/prepare-the-project-environment.md
+++ b/foundations/prepare-the-project-environment.md
@@ -37,7 +37,7 @@ This takes about 30 minutes and will print a numerical value for Estimated optim
 
 ## Create a heywhatsthat Panorama ID
 
-Heywhatsthat is a website that can generate an overlay on your map that will show the theoretical range of your location based on obstacles and the curvature of the earth. Follow step 1 at the instructions [here](https://github.com/wiedehopf/tar1090#heywhatsthatcom-range-outline) to generate a panorama for your feeder's location and altitude. In the upper left of the panorma page there will be a URL that will look like this: https://www.heywhatsthat.com/?view=NN3NNNN1. That code will be used later in the setup instructions.
+Heywhatsthat is a website that can generate an overlay on your map that will show the theoretical range of your location based on obstacles and the curvature of the earth. Follow step 1 at the instructions [here](https://github.com/wiedehopf/tar1090#heywhatsthatcom-range-outline) to generate a panorama for your feeder's location and altitude. In the upper left of the panorma page there will be a URL that will look like this: `https://www.heywhatsthat.com/?view=NN3NNNN1`. That code will be used later in the setup instructions.
 
 ## Create a `.env` file to hold our environment's variables
 
@@ -71,7 +71,7 @@ FEEDER_HEYWHATSTHAT_ALTS=<desired theoretical range altitudes>
 * `FEEDER_ALT_M` is set to your antenna's height in metres above [mean sea level](https://www.freemaptools.com/elevation-finder.htm)
 * `FEEDER_LAT` is set to your antenna's latitude (also available at link above)
 * `FEEDER_LONG` is set to your antenna's longitude (also available at link above)
-* `FEEDER_TZ` is set to your timezone, in ["TZ database name" format](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+* `FEEDER_TZ` is set to your timezone, in ["TZ database name" format](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). You can also see your Pi's timezone by giving this command: `cat /etc/timezone`
 * `FEEDER_NAME` is set to a location name. This is only used in the title of the map's web page.
 * `ADSB_SDR_SERIAL` is set to the serial number for your ADS-B dongle; the previous steps set this to 1090 by default but if you have used a different serial number enter it here
 * `ADSB_SDR_GAIN` is set to your desired dongle gain in dB, or `autogain` if you would like the software to determine the optimal gain

--- a/useful-extras/auto-restart-unhealthy-containers.md
+++ b/useful-extras/auto-restart-unhealthy-containers.md
@@ -68,7 +68,6 @@ Once the file has been updated, issue the command `docker compose up -d` in the 
 
 ```text
 ultrafeeder is up-to-date
-adsbx is up-to-date
 piaware is up-to-date
 fr24 is up-to-date
 pfclient is up-to-date
@@ -83,7 +82,7 @@ The container does not log any output, so check it is running by issuing the com
 The `autoheal` container logs when it restarts an unhealthy container, for example:
 
 ```text
-15-12-2020 20:17:06 Container /adsbx (51bc3e3511f5) found to be unhealthy - Restarting container now with 10s timeout
+15-12-2020 20:17:06 Container /fr24 (51bc3e3511f5) found to be unhealthy - Restarting container now with 10s timeout
 ```
 
 ## Only monitor and restart a specific set of containers
@@ -163,7 +162,6 @@ Once the file has been updated, issue the command `docker compose up -d` in the 
 
 ```text
 Recreating ultrafeeder
-adsbx is up-to-date
 piaware is up-to-date
 fr24 is up-to-date
 pfclient is up-to-date

--- a/useful-extras/auto-upgrade-containers.md
+++ b/useful-extras/auto-upgrade-containers.md
@@ -71,7 +71,6 @@ Once the file has been updated, issue the command `docker compose up -d` in the 
 
 ```text
 ultrafeeder is up-to-date
-adsbx is up-to-date
 piaware is up-to-date
 fr24 is up-to-date
 pfclient is up-to-date


### PR DESCRIPTION
- Added guidance on determining PPM Added instructions to set a UUID and put it in a variable Added instructions to set ADSB_SDR_SERIAL and ADSB_SDR_PPM and ADSB_SDR_GAIN
- Added instructions to determine PPM Added instructions to configure UAT_SDR_SERIAL and UAT_SDR_PPM and UAT_SDR_GAIN
- Moved UUID section to the prepare application environment page Added section about UUID security Remvoed FEEDER_NAME/MLAT_USER Removed sample code lines for piaware, rbfeeder, radarvirtuel, dump978 and moved them to those specific setup pages
- Added instructions on updating ultrafeeder for piaware MLAT
- Added instructions for updating ultrafeeder config to read MLAT from radarbox
- Added instructions to update ultrafeeder config to read MLAT from RV
- Removed reference to adsbx container Added instructions to update ultrafeeder config to send to ADSB Exchange
- Fixed typo referrring to 978 in the PPM section
- Typo fixes
- Moved dump978 GRAPHS1090 config instructions to dump978 gitbook page
- heywhatsthat instructions, Typo fixes, removal of adsbx container references
- Make heywhatsthat example URL generic
