### PR TITLE
Add missing trailing '/' to /graphs1090

### DIFF
--- a/foundations/deploy-ultrafeeder-container.md
+++ b/foundations/deploy-ultrafeeder-container.md
@@ -205,7 +205,7 @@ NETWORK ID     NAME           DRIVER    SCOPE
 If configured and started using the example above, the container will make a website available at port 8080 of your host machine. Here are a few web pages that are generated (replace `my_host_ip` with the name or IP address of your host machine):
 
 * `http://my_host_ip:8080/` : `tar1090` map and table of all aircraft received
-* `http://my_host_ip:8080/graphs1090` : page with graphs and operations statistics of your station
+* `http://my_host_ip:8080/graphs1090/` : page with graphs and operations statistics of your station
 * `http://my_host_ip:8080?pTracks` : showing all aircraft tracks received in the last 24 hours
 * `http://my_host_ip:8080?heatmap&realheat` : showing a heatmap of all aircrafts of the last 24 hours
 * `http://my_host_ip:8080?replay` : showing a timelapse replay of the past few days


### PR DESCRIPTION
If you omit the trailing '/' the Nginx proxy will redirect to port 80 instead of the port in the original request URI:

```
❯ http -v black-pearl.local:8080/graphs1090
GET /graphs1090 HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate
Connection: keep-alive
Host: black-pearl.local:8080
User-Agent: HTTPie/3.2.2



HTTP/1.1 301 Moved Permanently
Cache-Control: public, max-age=0
Connection: keep-alive
Content-Length: 162
Content-Type: text/html
Date: Mon, 12 Jun 2023 14:04:30 GMT
Location: http://black-pearl.local/graphs1090/
Server: nginx

<html>
<head><title>301 Moved Permanently</title></head>
<body>
<center><h1>301 Moved Permanently</h1></center>
<hr><center>nginx</center>
</body>
</html>
```

-> note how it redirects to "black-pearl.local/" instead of "black-pearl.local:8080/"