### PR TITLE
add short blurb about adsb.im

### DIFF
--- a/intro/how-to-get-help.md
+++ b/intro/how-to-get-help.md
@@ -3,3 +3,9 @@
 You can get help by [joining our Discord](https://discord.gg/sTf9uYF), and asking your question in the `#adsb-containers` channel. There are a bunch of friendly and knowledgeable people there who would be happy to help.
 
 Furthermore, we welcome any feedback on this document. If you think a section needs better instructions or further explanation, or if anything doesn't work for you, please let us know through the channels above so that we can continue to improve this document. [Open an issue on GitHub](https://github.com/sdr-enthusiasts/gitbook-adsb-guide/issues) or [submit a pull request](https://github.com/sdr-enthusiasts/gitbook-adsb-guide/pulls) with suggested changes!
+
+## All This Feels Like Too Much
+
+While following this guide is a great way to learn more about Docker and to better understand a fairly complex system with many interconnected components, some people might prefer the __easy__ button. You can get a simple to use image designed for common single board computers, including most of the recent Raspberry Pis, that comes with a straight forward Web UI and hides all of the complexity described here from you. You can find more about this at the [ADSB Feeder Image website](https://adsb.im/home). This project is built on top of the containers described in this document and actively maintained in collaboration with the maintainers of these containers (as well as the authors of some of the underlying tools). Questions about this project can be posted at the Discord mentioned above or in the [dedicated Zulip channel](https://adsblol.zulipchat.com/#narrow/stream/391168-adsb-feeder-image).
+
+But now back to the in depth technical information about how to set up your own feeder.


### PR DESCRIPTION
Try to find a balance of encouraging people to learn about Docker and the interconnected system that creates a modern feeder, and making sure that people who are looking for an easier solution aren't discouraged but instead pointed at something that requires a far less steep learning curve.


## note

Fred suggested on Discord that I should submit a brief note about using
the ADSB Feeder Image as an easier way to get started. Feel free to edit
and rephrase what I'm suggesting. The idea is to offer people who are
discouraged by the required base skills to get going with this guide an
easier way to get started.
