### PR TITLE
Update deploy-ultrafeeder-container.md to revise autogain command

### DIFF
--- a/foundations/deploy-ultrafeeder-container.md
+++ b/foundations/deploy-ultrafeeder-container.md
@@ -291,6 +291,6 @@ It is possible that you won't see any planes, either with the docker command abo
 
 ```bash
 cd /opt/adsb
-docker exec -it ultrafeeder /usr/local/bin/autogain1090 reset
 docker compose up -d
+docker exec -it ultrafeeder /usr/local/bin/autogain1090 reset
 ```

--- a/foundations/deploy-ultrafeeder-container.md
+++ b/foundations/deploy-ultrafeeder-container.md
@@ -291,6 +291,6 @@ It is possible that you won't see any planes, either with the docker command abo
 
 ```bash
 cd /opt/adsb
-docker exec -it ultrafeeder autogain reset
+docker exec -it ultrafeeder /usr/local/bin/autogain1090 reset
 docker compose up -d
 ```


### PR DESCRIPTION
As published, the autogain init command results in error:
```
docker exec -it ultrafeeder autogain reset
OCI runtime exec failed: exec failed: unable to start container process: exec: "autogain": executable file not found in $PATH: unknown

```
Per the readme on Github, the revised command yields success:
```
docker exec -it ultrafeeder /usr/local/bin/autogain1090 reset
Reset AutoGain - restarting with initial values and initialization process

```
Source:
https://github.com/sdr-enthusiasts/docker-adsb-ultrafeeder#user-content-autogain-for-rtlsdr-devices