### PR TITLE
Fixes non-functioning autogain reset call

### DIFF
--- a/foundations/deploy-ultrafeeder-container.md
+++ b/foundations/deploy-ultrafeeder-container.md
@@ -304,6 +304,6 @@ It is possible that you won't see any planes, either with the docker command abo
 
 ```bash
 cd /opt/adsb
-docker exec -it ultrafeeder autogain reset
+docker exec -it ultrafeeder /usr/local/bin/autogain1090 reset
 docker compose up -d
 ```


### PR DESCRIPTION
The original command wouldn't run on my `ultrafeeder` container. I found [this one](https://github.com/sdr-enthusiasts/docker-adsb-ultrafeeder/blob/e6320b193c8c2f38317492df6243e560f0680b5a/README.md?plain=1#L264) in the docs that did work.