### PR TITLE
Remove READSB_MODEAC=true from suggested/example ultrafeeder config

### DIFF
--- a/foundations/deploy-ultrafeeder-container.md
+++ b/foundations/deploy-ultrafeeder-container.md
@@ -53,7 +53,6 @@ services:
       - READSB_LON=${FEEDER_LONG}
       - READSB_ALT=${FEEDER_ALT_M}m
       - READSB_GAIN=${ADSB_SDR_GAIN}
-      - READSB_MODEAC=true
       - READSB_RX_LOCATION_ACCURACY=2
       - READSB_STATS_RANGE=true
       #


### PR DESCRIPTION
Remove READSB_MODEAC=true from suggested/example ultrafeeder config

None of the feeder sites process Mode A/C messages, it just wastes CPU cycles to decode these.