### PR TITLE
more visibility for the adsb.im Feeder Image

### DIFF
--- a/intro/how-to-get-help.md
+++ b/intro/how-to-get-help.md
@@ -6,6 +6,10 @@ Furthermore, we welcome any feedback on this document. If you think a section ne
 
 ## All This Feels Like Too Much
 
-While following this guide is a great way to learn more about Docker and to better understand a fairly complex system with many interconnected components, some people might prefer the __easy__ button. You can get a simple to use image designed for common single board computers, including most of the recent Raspberry Pis, that comes with a straight forward Web UI and hides all of the complexity described here from you. You can find more about this at the [ADSB Feeder Image website](https://adsb.im/home). This project is built on top of the containers described in this document and actively maintained in collaboration with the maintainers of these containers (as well as the authors of some of the underlying tools). Questions about this project can be posted at the Discord mentioned above or in the [dedicated Zulip channel](https://adsblol.zulipchat.com/#narrow/stream/391168-adsb-feeder-image).
+While following this guide is a great way to learn more about Docker and to better understand a fairly complex system with many interconnected components, some people might prefer the __easy__ button. You can get a simple to use image designed for common single board computers, including most of the recent Raspberry Pis, that comes with a straight forward Web UI and hides all of the complexity described here from you. You can find more about this at the [adsb.im Feeder Image website](https://adsb.im/home). This project is built on top of the containers described in this document and actively maintained in collaboration with the maintainers of these containers (as well as the authors of some of the underlying tools).
+
+Or, as sort of a middle ground, you can install the same well maintained software stack on most current Linux distributions, and especially easily on any DietPi system, where it is directly available through the dietpi-software app (as application #141).
+
+Questions about this project can be posted at the Discord mentioned above or in the [dedicated Zulip channel](https://adsblol.zulipchat.com/#narrow/stream/391168-adsb-feeder-image).
 
 But now back to the in depth technical information about how to set up your own feeder.

--- a/intro/overview.md
+++ b/intro/overview.md
@@ -42,3 +42,9 @@ All of the containers in this guide will run on:
 This mix of architectures allows you to run this set-up this on almost any Linux machine.
 
 If there's another feeder you'd like added as a container, please reach out to me via the methods outlined below.
+
+# Shortcuts
+
+Following this guide is not very hard, but it does require some familiarity with the command line, editing files, and some patience as you work through the details.
+If you are looking for an easier option, the [How To Get Help](intro/how-to-get-help) section introduces the [adsb.im Feeder Image](https://adsb.im/home) which is designed to make things even easier.
+


### PR DESCRIPTION
This adds a link in the Overview section (because apparently people aren't reading the how to get help section when looking for something that's easier???), and also expands the description a little more to mention the app mode and especially the direct install on DietPi.