### PR TITLE
Slight fixing up of the Prometheus exporter section of the Timeseries docs

### DIFF
--- a/useful-extras/storing-time-series-data.md
+++ b/useful-extras/storing-time-series-data.md
@@ -140,6 +140,6 @@ These variables control exposing flight data and `readsb` metrics to [Prometheus
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `ENABLE_PROMETHEUS` | Set to any string to enable Prometheus support | Unset |
+| `PROMETHEUS_ENABLE` | Set to any string to enable Prometheus support | Unset |
 | `PROMETHEUSPORT` | The port that the Prometheus client will listen on | `9273` |
 | `PROMETHEUSPATH` | The path that the Prometheus client will publish metrics on | `/metrics` |

--- a/useful-extras/storing-time-series-data.md
+++ b/useful-extras/storing-time-series-data.md
@@ -136,10 +136,9 @@ Field keys should be as-per the `StatisticEntry` message schema from [`readsb.pr
 
 ## Prometheus Options
 
-These variables control exposing flight data and `readsb` metrics to [Prometheus](https://prometheus.io) (via a built-in instance of [Telegraf](https://docs.influxdata.com/telegraf/)).
+These variables control exposing flight data and `readsb` metrics to [Prometheus](https://prometheus.io) (via a built-in instance of [Telegraf](https://docs.influxdata.com/telegraf/)). The metrics will be available under any path on the chosen port.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `PROMETHEUS_ENABLE` | Set to any string to enable Prometheus support | Unset |
 | `PROMETHEUSPORT` | The port that the Prometheus client will listen on | `9273` |
-| `PROMETHEUSPATH` | The path that the Prometheus client will publish metrics on | `/metrics` |

--- a/useful-extras/storing-time-series-data.md
+++ b/useful-extras/storing-time-series-data.md
@@ -141,4 +141,4 @@ These variables control exposing flight data and `readsb` metrics to [Prometheus
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `PROMETHEUS_ENABLE` | Set to any string to enable Prometheus support | Unset |
-| `PROMETHEUSPORT` | The port that the Prometheus client will listen on | `9273` |
+| `PROMETHEUSPORT` | The port that the Prometheus client will listen on | `9274` |


### PR DESCRIPTION
Few nitpick things:

* The variable to enable Prometheus didn't match the code
* The default port differed from the code
* The docs suggest you can specify a path, but the code actually serves on any path

*Note*: I also raised https://github.com/sdr-enthusiasts/docker-adsb-ultrafeeder/pull/64 to allow changing of the port.
