### PR TITLE
Minor guide edits to match output in current scripts

### DIFF
--- a/feeder-containers/feeding-adsbhub.md
+++ b/feeder-containers/feeding-adsbhub.md
@@ -12,7 +12,7 @@ The docker image [`ghcr.io/sdr-enthusiasts/docker-adsbhub`](https://github.com/s
 
 ### Obtaining an ADSBHub Station Key
 
-First-time users should obtain a ADSBHub Station dynamic IP key. Follow the directions for steps 1 and 2 at [ADSBHub how to feed](https://www.adsbhub.org/howtofeed.php), ensuring your station is set up as a client and the data protocol set as "SBS".
+First-time users should obtain a ADSBHub Station dynamic IP key. Follow the directions for steps 1 and 2 at [ADSBHub how to feed](https://www.adsbhub.org/howtofeed.php), ensuring your station is set up as a client and the data protocol set as "SBS" (see below.)
 
 Existing users should sign in to their ADSBHub account, go to their "Settings" page, click on their station \(in the bar at the top of the settings table\) and retrieve their station key.
 
@@ -76,11 +76,10 @@ To explain what's going on in this addition:
 Once the file has been updated, issue the command `docker compose up -d` in the application directory to apply the changes and bring up the `adsbhub` container. You should see the following output:
 
 ```text
-ultrafeeder is up-to-date
-piaware is up-to-date
-fr24 is up-to-date
-pfclient is up-to-date
-Creating adsbhub
+ ✔ Container ultrafeeder  Running
+ ✔ Container piaware      Running
+ ✔ Container fr24         Running 
+ ✔ Container adsbhub      Started
 ```
 
 We can view the logs for the environment with the command `docker logs adsbhub`, or continually "tail" them with `docker logs -f adsbhub`. The logs will be fairly unexciting and look like this:

--- a/feeder-containers/feeding-flightaware-piaware.md
+++ b/feeder-containers/feeding-flightaware-piaware.md
@@ -133,6 +133,8 @@ To explain what's going on in this addition:
 
 Before running `docker compose`, we also want to update the configuration of the `ultrafeeder` container, so that it generates MLAT data for piaware.
 
+**NOTE: If you are using the sample `docker-compose.yml` provided, this step has already been done for you.**
+
 Open the `docker-compose.yml` and make the following environment value is part of the `ULTRAFEEDER_CONFIG` variable to the `ultrafeeder` service:
 
 ```yaml
@@ -146,8 +148,8 @@ To explain this addition, the `ultrafeeder` container will connect to the `piawa
 Once the file has been updated, issue the command `docker compose up -d` in the application directory to apply the changes and bring up the `piaware` container. You should see the following output:
 
 ```text
-ultrafeeder is up-to-date
-Creating piaware
+ ✔ Container ultrafeeder  Running
+ ✔ Container piaware   Started
 ```
 
 We can view the logs for the environment with the command `docker compose logs`, or continually "tail" them with `docker compose logs -f`. At this stage, the logs will be fairly unexciting and look like this:

--- a/feeder-containers/feeding-flightradar24.md
+++ b/feeder-containers/feeding-flightradar24.md
@@ -110,9 +110,9 @@ To explain what's going on in this addition:
 Once the file has been updated, issue the command `docker compose up -d` in the application directory to apply the changes and bring up the `fr24` container. You should see the following output:
 
 ```text
-ultrafeeder is up-to-date
-piaware is up-to-date
-Creating fr24
+ ✔ Container ultrafeeder  Running
+ ✔ Container piaware      Running
+ ✔ Container fr24         Started
 ```
 
 We can view the logs for the environment with the command `docker compose logs`, or continually "tail" them with `docker compose logs -f`. At this stage, the logs will be fairly unexciting and look like this:

--- a/feeder-containers/feeding-opensky-network.md
+++ b/feeder-containers/feeding-opensky-network.md
@@ -169,12 +169,11 @@ To explain what's going on in this addition:
 Once the file has been updated, issue the command `docker compose up -d` in the application directory to apply the changes and bring up the `adsbhub` container. You should see the following output:
 
 ```text
-ultrafeeder is up-to-date
-piaware is up-to-date
-fr24 is up-to-date
-pfclient is up-to-date
-adsbhub is up-to-date
-Creating opensky
+ ✔ Container ultrafeeder  Running
+ ✔ Container piaware      Running
+ ✔ Container fr24         Running 
+ ✔ Container adsbhub      Running
+ ✔ Container opensky      Started
 ```
 
 We can view the logs for the environment with the command `docker logs opensky`, or continually "tail" them with `docker logs -f opensky`. The logs will be fairly unexciting and look like this:

--- a/feeder-containers/feeding-plane-watch.md
+++ b/feeder-containers/feeding-plane-watch.md
@@ -83,8 +83,8 @@ To explain what's going on in this addition:
 Once the file has been updated, issue the command `docker compose up -d` in the application directory to apply the changes and bring up the `planewatch` container. You should see the following output:
 
 ```text
-ultrafeeder is up-to-date
-Creating planewatch
+ ✔ Container ultrafeeder  Running
+ ✔ Container planewatch   Started
 ```
 
 You can see from the output above that the `ultrafeeder` container was left alone \(as the configuration for this container did not change\), and a new container `planewatch` was created.

--- a/feeder-containers/feeding-planefinder.md
+++ b/feeder-containers/feeding-planefinder.md
@@ -118,10 +118,10 @@ To explain what's going on in this addition:
 Once the file has been updated, issue the command `docker compose up -d` in the application directory to apply the changes and bring up the `pfclient` container. You should see the following output:
 
 ```text
-ultrafeeder is up-to-date
-piaware is up-to-date
-fr24 is up-to-date
-Creating pfclient
+ ✔ Container ultrafeeder  Running
+ ✔ Container piaware      Running
+ ✔ Container fr24         Running 
+ ✔ Container pfclient     Started
 ```
 
 We can view the logs for the environment with the command `docker compose logs`, or continually "tail" them with `docker compose logs -f`. At this stage, the logs will be fairly unexciting and look like this:

--- a/feeder-containers/feeding-radarbox.md
+++ b/feeder-containers/feeding-radarbox.md
@@ -185,6 +185,8 @@ To explain what's going on in this addition:
 
 Before running `docker compose`, we also want to update the configuration of the `ultrafeeder` container, so that it generates MLAT data for radarbox.
 
+**NOTE: If you are using the sample `docker-compose.yml` provided, this step has already been done for you.**
+
 Open the `docker-compose.yml` and make the following environment value is part of the `ULTRAFEEDER_CONFIG` variable to the `ultrafeeder` service:
 
 ```yaml
@@ -198,10 +200,10 @@ To explain this addition, the `ultrafeeder` container will connect to the `rbfee
 Once the file has been updated, issue the command `docker compose up -d` in the application directory to apply the changes and bring up the `rbfeeder` container. You should see the following output:
 
 ```text
-ultrafeeder is up-to-date
-piaware is up-to-date
-fr24 is up-to-date
-Creating rbfeeder
+ ✔ Container ultrafeeder  Running
+ ✔ Container piaware      Running
+ ✔ Container fr24         Running
+ ✔ Container rbfeeder     Started
 ```
 
 We can view the logs for the environment with the command `docker compose logs`, or continually "tail" them with `docker compose logs -f`. At this stage, the logs will be fairly unexciting and look like this:

--- a/feeder-containers/feeding-radarvirtuel.md
+++ b/feeder-containers/feeding-radarvirtuel.md
@@ -99,11 +99,11 @@ To explain this addition, the `ultrafeeder` container will connect to the `radar
 Once the file has been updated, issue the command `docker compose pull radarvirtuel && docker compose up -d` in the application directory to apply the changes and bring up the `radarvirtuel` container. You should see the following output:
 
 ```text
-ultrafeeder is up-to-date
-piaware is up-to-date
-fr24 is up-to-date
-pfclient is up-to-date
-Creating radarvirtuel...
+ ✔ Container ultrafeeder  Running
+ ✔ Container piaware      Running
+ ✔ Container fr24         Running 
+ ✔ Container adsbhub      Running
+ ✔ Container radarvirtuel Started
 ```
 
 We can view the logs for the environment with the command `docker logs radarvirtuel`, or continually "tail" them with `docker logs -f radarvirtuel`. The logs will be fairly unexciting and look like this:

--- a/foundations/deploy-ultrafeeder-container.md
+++ b/foundations/deploy-ultrafeeder-container.md
@@ -169,8 +169,8 @@ docker compose up -d
 You should see the following output:
 
 ```text
-Creating network "adsb_default" with the default driver
-Creating ultrafeeder         ... done
+ ⠴ Network adsb_default   Created
+ ✔ Container ultrafeeder  Started
 ```
 
 We can view the logs for the environment with the command `docker compose logs`, or continually "tail" them with `docker compose logs -f`. At this stage, the logs will be fairly extensive and unexciting and look like this:

--- a/foundations/deploy-ultrafeeder-container.md
+++ b/foundations/deploy-ultrafeeder-container.md
@@ -70,6 +70,7 @@ services:
           adsb,skyfeed.hpradar.com,30004,beast_reduce_plus_out;
           adsb,feed.radarplane.com,30001,beast_reduce_plus_out;
           adsb,dati.flyitalyadsb.com,4905,beast_reduce_plus_out;
+          adsb,feed1.adsbexchange.com,30004,beast_reduce_plus_out;
           mlat,feed.adsb.fi,31090,39000;
           mlat,in.adsb.lol,31090,39001;
           mlat,feed.airplanes.live,31090,39002;
@@ -78,6 +79,7 @@ services:
           mlat,skyfeed.hpradar.com,31090,39005;
           mlat,feed.radarplane.com,31090,39006;
           mlat,dati.flyitalyadsb.com,30100,39007;
+          mlat,feed.adsbexchange.com,31090,39008
           mlathub,piaware,30105,beast_in;
           mlathub,rbfeeder,30105,beast_in;
           mlathub,radarvirtuel,30105,beast_in;

--- a/foundations/deploy-ultrafeeder-container.md
+++ b/foundations/deploy-ultrafeeder-container.md
@@ -14,8 +14,6 @@ nano docker-compose.yml
 ```
 
 ```yaml
-version: '3.8'
-
 services:
   ultrafeeder:
   # ultrafeeder combines a number of functions:


### PR DESCRIPTION
I've made a bunch of minor edits to the guide, mostly to update the Docker Compose output to match more recent versions.

Also enabled adbsx in the sample ultrafeeder `docker-compose.yml` provided to match the feeds matrix.  If this commit isn't desired, I'll submit another PR to remove adbsx from the default feeds matrix.

Noted when mlathub configs may have already been done