### PR TITLE
Fix typo in description

### DIFF
--- a/feeder-containers/feeding-flightradar24.md
+++ b/feeder-containers/feeding-flightradar24.md
@@ -1,5 +1,5 @@
 ---
-description: 'If you wish to feed FlightAware, follow the steps below.'
+description: 'If you wish to feed FlightRadar24, follow the steps below.'
 ---
 
 # Feeding FlightRadar24


### PR DESCRIPTION
As this description is on the site describing feeding to FlightRadar24, the name in line 2 should reflect that.