### PR TITLE
remove tty: true

### DIFF
--- a/feeder-containers/feeding-adsbhub.md
+++ b/feeder-containers/feeding-adsbhub.md
@@ -56,7 +56,6 @@ Append the following lines to the end of the file \(inside the `services:` secti
 ```yaml
   adsbhub:
     image: ghcr.io/sdr-enthusiasts/docker-adsbhub:latest
-    tty: true
     container_name: adsbhub
     restart: unless-stopped
     environment:

--- a/feeder-containers/feeding-flightaware-piaware.md
+++ b/feeder-containers/feeding-flightaware-piaware.md
@@ -92,7 +92,6 @@ Append the following lines to the end of the file \(inside the `services:` secti
 ```yaml
   piaware:
     image: ghcr.io/sdr-enthusiasts/docker-piaware:latest
-    tty: true
     container_name: piaware
     restart: unless-stopped
     ports:

--- a/feeder-containers/feeding-flightradar24.md
+++ b/feeder-containers/feeding-flightradar24.md
@@ -97,7 +97,6 @@ Append the following lines to the end of the file \(inside the `services:` secti
 ```yaml
   fr24:
     image: ghcr.io/sdr-enthusiasts/docker-flightradar24:latest
-    tty: true
     container_name: fr24
     restart: unless-stopped
     ports:

--- a/feeder-containers/feeding-new-aggregators.md
+++ b/feeder-containers/feeding-new-aggregators.md
@@ -32,7 +32,6 @@ Append the following lines to the end of the file \(inside the `services:` secti
 ```yaml
   multifeeder:
     image: ghcr.io/sdr-enthusiasts/docker-multifeeder
-    tty: true
     container_name: multifeeder
     hostname: multifeeder
     restart: unless-stopped

--- a/feeder-containers/feeding-opensky-network.md
+++ b/feeder-containers/feeding-opensky-network.md
@@ -135,7 +135,6 @@ Append the following lines to the end of the file \(inside the `services:` secti
 ```yaml
   opensky:
     image: ghcr.io/sdr-enthusiasts/docker-opensky-network:latest
-    tty: true
     container_name: opensky
     restart: unless-stopped
     environment:

--- a/feeder-containers/feeding-plane-watch.md
+++ b/feeder-containers/feeding-plane-watch.md
@@ -51,7 +51,6 @@ Append the following lines to the end of the file \(inside the `services:` secti
 ```yaml
   planewatch:
     image: ghcr.io/plane-watch/docker-plane-watch:latest
-    tty: true
     container_name: planewatch
     restart: unless-stopped
     environment:

--- a/feeder-containers/feeding-planefinder.md
+++ b/feeder-containers/feeding-planefinder.md
@@ -88,7 +88,6 @@ Append the following lines to the end of the file \(inside the `services:` secti
     image: ghcr.io/sdr-enthusiasts/docker-planefinder:latest
     # If you are running on a Raspberry Pi 5, uncomment the below line and comment out the above
     #ghcr.io/sdr-enthusiasts/docker-planefinder:5.0.161_arm64
-    tty: true
     container_name: pfclient
     restart: unless-stopped
     ports:

--- a/feeder-containers/feeding-radarbox.md
+++ b/feeder-containers/feeding-radarbox.md
@@ -144,7 +144,6 @@ Append the following lines to the end of the file \(inside the `services:` secti
 ```yaml
   rbfeeder:
     image: ghcr.io/sdr-enthusiasts/docker-radarbox:latest
-    tty: true
     container_name: rbfeeder
     restart: unless-stopped
     environment:

--- a/feeder-containers/feeding-radarplane.md
+++ b/feeder-containers/feeding-radarplane.md
@@ -69,7 +69,6 @@ An example docker compose service definition is below:
 ```yaml
   radarplane:
     image: ghcr.io/radarplane/docker-radarplane:main
-    tty: true
     container_name: radarplane
     restart: unless-stopped
     environment:

--- a/feeder-containers/feeding-radarvirtuel.md
+++ b/feeder-containers/feeding-radarvirtuel.md
@@ -50,7 +50,6 @@ Append the following lines to the end of the file (inside the `services:` sectio
 ```yaml
   radarvirtuel:
     image: ghcr.io/sdr-enthusiasts/docker-radarvirtuel:latest
-    tty: true
     container_name: radarvirtuel
     hostname: radarvirtuel
     restart: unless-stopped

--- a/foundations/deploy-dump978-usa-only.md
+++ b/foundations/deploy-dump978-usa-only.md
@@ -59,7 +59,6 @@ Append the following lines to the end of the file \(under the `services:` sectio
 ```yaml
   dump978:
     image: ghcr.io/sdr-enthusiasts/docker-dump978:latest
-    tty: true
     container_name: dump978
     restart: unless-stopped
     device_cgroup_rules:

--- a/foundations/deploy-readsb-container.md
+++ b/foundations/deploy-readsb-container.md
@@ -23,7 +23,6 @@ volumes:
 services:
   readsb:
     image: ghcr.io/sdr-enthusiasts/docker-readsb-protobuf:latest
-    tty: true
     container_name: readsb
     hostname: readsb
     restart: unless-stopped

--- a/useful-extras/alternative-graphing-with-influx-grafana.md
+++ b/useful-extras/alternative-graphing-with-influx-grafana.md
@@ -53,7 +53,6 @@ Append the following lines to the end of the file:
 ```yaml
   influxdb:
     image: influxdb:latest
-    tty: true
     container_name: influxdb
     hostname: influxdb
     restart: unless-stopped
@@ -73,7 +72,6 @@ Append the following lines to the end of the file:
 
   grafana:
     image: grafana/grafana-oss:latest
-    tty: true
     container_name: grafana
     hostname: grafana
     restart: unless-stopped

--- a/useful-extras/auto-restart-unhealthy-containers.md
+++ b/useful-extras/auto-restart-unhealthy-containers.md
@@ -48,7 +48,6 @@ Append the following lines to the end of the file \(inside the `services:` secti
 ```yaml
   autoheal:
     image: willfarrell/autoheal:latest
-    tty: true
     container_name: autoheal
     restart: unless-stopped
     environment:
@@ -110,7 +109,6 @@ volumes:
 services:
   readsb:
     image: ghcr.io/sdr-enthusiasts/docker-readsb-protobuf:latest
-    tty: true
     container_name: readsb
     hostname: readsb
     restart: unless-stopped
@@ -146,7 +144,6 @@ Append the following lines to the end of the file \(inside the `services:` secti
 ```yaml
   autoheal:
     image: willfarrell/autoheal:latest
-    tty: true
     container_name: autoheal
     restart: unless-stopped
     volumes:

--- a/useful-extras/auto-upgrade-containers.md
+++ b/useful-extras/auto-upgrade-containers.md
@@ -45,7 +45,6 @@ Append the following lines to the end of the file \(inside the `services:` secti
 ```yaml
   watchtower:
     image: containrrr/watchtower:latest
-    tty: true
     container_name: watchtower
     restart: unless-stopped
     environment:

--- a/useful-extras/improved-visualisation-with-tar1090.md
+++ b/useful-extras/improved-visualisation-with-tar1090.md
@@ -31,7 +31,6 @@ Append the following lines to the end of the file:
 ```yaml
   tar1090:
     image: ghcr.io/sdr-enthusiasts/docker-tar1090:latest
-    tty: true
     container_name: tar1090
     restart: unless-stopped
     environment:


### PR DESCRIPTION
this should not be required for any containers
it can cause issues in conjunction with a /dev read-only mount and recent docker versions