### PR TITLE
Fixing code blocks

### DIFF
--- a/feeder-containers/feeding-adsbhub.md
+++ b/feeder-containers/feeding-adsbhub.md
@@ -28,13 +28,13 @@ In your station preferences, you should set the following:
 
 Inside your application directory \(`/opt/adsb`\), edit the `.env` file using your favourite text editor. Beginners may find the editor `nano` easy to use:
 
-```text
+```shell
 nano /opt/adsb/.env
 ```
 
 This file holds all of the commonly used variables \(such as our latitude, longitude and altitude\). We're going to add our ADSBHub Station Key to this file. Add the following line to the file:
 
-```text
+```shell
 ADSBHUB_STATION_KEY='YOURSTATIONKEY'
 ```
 
@@ -43,7 +43,7 @@ ADSBHUB_STATION_KEY='YOURSTATIONKEY'
 
 For example:
 
-```text
+```shell
 ADSBHUB_STATION_KEY='vrMr@AZn660X0H^0Usn~rcj$UJA7VlR.vEu4c;uh7mfU-J9ZUBXpJiUuWj37DTa5BtL'
 ```
 

--- a/feeder-containers/feeding-airnavradar.md
+++ b/feeder-containers/feeding-airnavradar.md
@@ -27,8 +27,7 @@ You'll need a _sharing key_. To get one, you can temporarily run the container, 
 
 Inside your application directory \(`/opt/adsb`\), run the following commands:
 
-```bash
-docker pull ghcr.io/sdr-enthusiasts/docker-airnavradar:latest
+```shell
 source ./.env
 timeout 60 docker run \
     --rm \
@@ -38,7 +37,7 @@ timeout 60 docker run \
     -e LAT=${FEEDER_LAT} \
     -e LONG=${FEEDER_LONG} \
     -e ALT=${FEEDER_ALT_M} \
-    ghcr.io/sdr-enthusiasts/docker-airnavradar
+    ghcr.io/sdr-enthusiasts/docker-airnavradar:latest
 ```
 
 The command will run the container for one minute, which should be ample time for the container to connect to Airnav Radar receive a sharing key.
@@ -95,13 +94,13 @@ As you can see from the output above, the sharing key given to us from Airnav Ra
 
 If the script doesn't output the sharing key, it can be found by using the following command:
 
-```bash
+```shell
 docker exec -it rbfeeder /bin/sh -c "cat /etc/rbfeeder.ini" | grep key
 ```
 
 Command output:
 
-```text
+```shell
 key=g45643ab345af3c5d5g923a99ffc0de9
 ```
 
@@ -115,13 +114,13 @@ key=g45643ab345af3c5d5g923a99ffc0de9
 
 Inside your application directory \(`/opt/adsb`\), edit the `.env` file using your favourite text editor. Beginners may find the editor `nano` easy to use:
 
-```bash
+```shell
 nano /opt/adsb/.env
 ```
 
 This file holds all of the commonly used variables \(such as our latitude, longitude and altitude\). We're going to add our `rbfeeder` sharing key to this file. Add the following line to the file:
 
-```bash
+```shell
 AIRNAVRADAR_SHARING_KEY=YOURSHARINGKEY
 ```
 
@@ -129,7 +128,7 @@ AIRNAVRADAR_SHARING_KEY=YOURSHARINGKEY
 
 For example:
 
-```bash
+```shell
 AIRNAVRADAR_SHARING_KEY=g45643ab345af3c5d5g923a99ffc0de9
 ```
 

--- a/feeder-containers/feeding-flightaware-piaware.md
+++ b/feeder-containers/feeding-flightaware-piaware.md
@@ -20,7 +20,7 @@ You'll need your _feeder-id_ from your existing feeder.
 
 To get your _feeder-id_, log onto your feeder via SSH and issue the command:
 
-```bash
+```shell
 piaware-config -show feeder-id
 ```
 
@@ -32,7 +32,7 @@ You'll need a _feeder-id_. To get one, you can temporarily run the container, to
 
 Inside your application directory \(`/opt/adsb`\), run the following commands:
 
-```text
+```shell
 docker pull ghcr.io/sdr-enthusiasts/docker-piaware:latest
 source ./.env
 timeout 60 docker run --rm -e LAT="$FEEDER_LAT" -e LONG="$FEEDER_LONG" ghcr.io/sdr-enthusiasts/docker-piaware:latest | grep "my feeder ID"
@@ -42,7 +42,7 @@ The command will run the container for 60 seconds, which should be ample time fo
 
 For example:
 
-```text
+```ShellSession
 $ timeout 60 docker run --rm LAT="$FEEDER_LAT" -e LONG="$FEEDER_LONG" ghcr.io/sdr-enthusiasts/docker-piaware:latest | grep "my feeder ID"
 Set allow-mlat to yes in /etc/piaware.conf:1
 Set allow-modeac to yes in /etc/piaware.conf:2
@@ -65,13 +65,13 @@ Note - for PiAware/FlightAware feeding to work correctly, you MUST accurately se
 
 Inside your application directory \(`/opt/adsb`\), edit the `.env` file using your favourite text editor. Beginners may find the editor `nano` easy to use:
 
-```bash
+```shell
 nano /opt/adsb/.env
 ```
 
 This file holds all of the commonly used variables \(such as our latitude, longitude and altitude\). We're going to add our `piaware` feeder-id to this file. Add the following line to the file:
 
-```text
+```shell
 PIAWARE_FEEDER_ID=YOURFEEDERID
 ```
 
@@ -79,7 +79,7 @@ PIAWARE_FEEDER_ID=YOURFEEDERID
 
 For example:
 
-```text
+```shell
 PIAWARE_FEEDER_ID=acbf1f88-09a4-3a47-a4a0-10ae138d0c1g
 ```
 

--- a/feeder-containers/feeding-flightradar24.md
+++ b/feeder-containers/feeding-flightradar24.md
@@ -18,7 +18,7 @@ You'll need your _fr24key_ from your existing feeder.
 
 To get your _fr24key_, log onto your feeder and issue the command:
 
-```bash
+```shell
 cat /etc/fr24feed.ini | grep fr24key
 ```
 
@@ -36,7 +36,7 @@ Use the same email address as for your fr24 account if you already have one or p
 
 Run the command:
 
-```text
+```shell
 docker run -it --rm ghcr.io/sdr-enthusiasts/docker-baseimage:qemu bash -c "$(curl -sSL https://raw.githubusercontent.com/sdr-enthusiasts/docker-flightradar24/main/get_adsb_key.sh)"
 ```
 
@@ -64,7 +64,7 @@ Congratulations! You are now registered and ready to share ADS-B data with Fligh
 
 Copy the sharing key you are given, and add the following line to your `.env` file:
 
-```text
+```shell
 FR24_SHARING_KEY=YOURSHARINGKEY
 ```
 
@@ -72,7 +72,7 @@ FR24_SHARING_KEY=YOURSHARINGKEY
 
 For example:
 
-```text
+```shell
 FR24_SHARING_KEY=10ae138d0c1g
 ```
 
@@ -82,7 +82,7 @@ Get a separate sharing key for UAT as described [here](https://github.com/sdr-en
 
 Copy the UAT sharing key you are given, and add the following line to your `.env` file:
 
-```text
+```shell
 FR24_SHARING_KEY_UAT=YOURSHARINGKEYUAT
 ```
 

--- a/feeder-containers/feeding-new-aggregators.md
+++ b/feeder-containers/feeding-new-aggregators.md
@@ -52,7 +52,7 @@ Append the following lines to the end of the file \(inside the `services:` secti
 
 If you already have a `UUID` that was generated for the ADSBExchange service, feel free to reuse that one. If you don't have one, you can generate one by logging onto you Linux machine (Raspberry Pi, etc.) and giving this command:
 
-```bash
+```shell
 cat  /proc/sys/kernel/random/uuid
 ```
 

--- a/feeder-containers/feeding-opensky-network.md
+++ b/feeder-containers/feeding-opensky-network.md
@@ -16,26 +16,40 @@ Firstly, make sure you have registered for an account on the [OpenSky Network we
 
 In order to obtain a feeder serial number, we will start a temporary container running `opensky-feeder`, which will connect to OpenSky Network and be issued a serial number. The temporary container will automatically be stopped and deleted after 60 seconds.
 
+Inside your application directory \(`/opt/adsb`\), edit the `.env` file using your favourite text editor. Beginners may find the editor `nano` easy to use:
+
+```shell
+nano /opt/adsb/.env
+```
+
+This file holds all of the commonly used variables \(such as our latitude, longitude and altitude\). We're going to add our OpenSky username to this file. Add the following line to the file:
+
+```shell
+OPENSKY_USERNAME='YOUROPENSKYUSERNAME'
+```
+
+* Replace `YOUROPENSKYUSERNAME` with the station key you retrieved earlier.
+
+For example:
+
+```shell
+OPENSKY_USERNAME=johnnytightlips
+```
+
 To do this, run the command:
 
-```text
+```shell
+source ./.env
 timeout 60s docker run \
     --rm \
     -it \
-    -e LAT=YOURLATITUDE \
-    -e LONG=YOURLONGITUDE \
-    -e ALT=YOURALTITUDE \
+    -e LAT=${FEEDER_LAT} \
+    -e LONG=${FEEDER_LONG} \
+    -e ALT=${FEEDER_ALT_M} \
     -e BEASTHOST=ultrafeeder\
-    -e OPENSKY_USERNAME=YOUROPENSKYUSERNAME \
-    ghcr.io/sdr-enthusiasts/docker-opensky-network
+    -e OPENSKY_USERNAME=${OPENSKY_USERNAME} \
+    ghcr.io/sdr-enthusiasts/docker-opensky-network:latest
 ```
-
-Be sure to change the following:
-
-* Replace `YOURLATITUDE` with the latitude of your antenna \(xx.xxxxx\)
-* Replace `YOURLONGITUDE` with the longitude of your antenna \(xx.xxxxx\)
-* Replace `YOURALTITUDE` with the altitude above sea level of your antenna _**in metres**_
-* Replace `YOUROPENSKYUSERNAME` with your OpenSky Network username
 
 Once the container has started, you should see output similar to the following:
 
@@ -103,23 +117,23 @@ As you can see from the output above, we've been allocated a serial number of `-
 
 Inside your application directory \(`/opt/adsb`\), edit the `.env` file using your favourite text editor. Beginners may find the editor `nano` easy to use:
 
-```text
+```shell
 nano /opt/adsb/.env
 ```
 
 This file holds all of the commonly used variables \(such as our latitude, longitude and altitude\). We're going to add our OpenSky-Network username and serial to this file. Add the following lines to the file:
 
-```text
+```shell
 OPENSKY_USERNAME=YOUROPENSKYUSERNAME
 OPENSKY_SERIAL=YOUROPENSKYSERIAL
 ```
 
-* Replace `YOUROPENSKYUSERNAME` with your OpenSky Network username
+* Replace `YOUROPENSKYUSERNAME` with your OpenSky Network username. Yo should have already done this in the previous step.
 * Replace `YOUROPENSKYSERIAL` with your OpenSky Network serial
 
 For example:
 
-```text
+```shell
 OPENSKY_USERNAME=johnnytightlips
 OPENSKY_SERIAL=-1408234269
 ```

--- a/feeder-containers/feeding-plane-watch.md
+++ b/feeder-containers/feeding-plane-watch.md
@@ -24,13 +24,13 @@ When you save your feeder, an **API Key** will be generated. Take note of this, 
 
 Inside your application directory \(`/opt/adsb`\), edit the `.env` file using your favourite text editor. Beginners may find the editor `nano` easy to use:
 
-```bash
+```shell
 nano /opt/adsb/.env
 ```
 
 This file holds all of the commonly used variables \(such as our latitude, longitude and altitude\). We're going to add our plane.watch variables to this file. Add the following lines to the file:
 
-```text
+```shell
 PW_API_KEY=YOURAPIKEY
 ```
 
@@ -38,7 +38,7 @@ PW_API_KEY=YOURAPIKEY
 
 For example:
 
-```text
+```shell
 PW_API_KEY=4e8413e6-52eb-11ea-8681-1c1b0d925d3g
 ```
 
@@ -127,5 +127,3 @@ After a few minutes, browse to [https://atc.plane.watch/](https://atc.plane.watc
 ## Advanced
 
 If you want to look at more options and examples for the `plane.watch` container, you can find the repository [here](https://github.com/plane-watch/docker-plane-watch).
-
-

--- a/feeder-containers/feeding-planefinder.md
+++ b/feeder-containers/feeding-planefinder.md
@@ -26,7 +26,7 @@ You'll need a _share code_. In order to obtain a PlaneFinder Share Code, we will
 
 Run the command:
 
-```text
+```shell
 docker run \
     --rm \
     -it \
@@ -59,13 +59,13 @@ You should now claim your receiver:
 
 Inside your application directory \(`/opt/adsb`\), edit the `.env` file using your favourite text editor. Beginners may find the editor `nano` easy to use:
 
-```text
+```shell
 nano /opt/adsb/.env
 ```
 
 This file holds all of the commonly used variables \(such as our latitude, longitude and altitude\). We're going to add our `pfclient` share code to this file. Add the following line to the file:
 
-```text
+```shell
 PLANEFINDER_SHARECODE=YOURSHARECODE
 ```
 
@@ -73,7 +73,7 @@ PLANEFINDER_SHARECODE=YOURSHARECODE
 
 For example:
 
-```text
+```shell
 PLANEFINDER_SHARECODE=zg84632abhf231
 ```
 
@@ -169,7 +169,7 @@ Once running, you can visit `http://docker.host.ip.addr:30053` to access the `pf
 
 If you are running a Raspberry Pi 5, then you may see the following messages in your Docker Compose log output:
 
-```
+```text
 pfclient      | [pfclient_daemon] /usr/local/bin/pfclient: error while loading shared libraries:
 pfclient      | [pfclient_daemon] /usr/local/bin/pfclient: error while loading shared libraries:
 pfclient      | [pfclient_daemon] /usr/local/bin/pfclient: error while loading shared libraries:

--- a/feeder-containers/feeding-radarplane.md
+++ b/feeder-containers/feeding-radarplane.md
@@ -39,22 +39,41 @@ First-time users should generate a static UUID using this command:
 cat /proc/sys/kernel/random/uuid
 ```
 
-Take note of the UUID returned. You should pass it as the `UUID` environment variable when running the container.
+Inside your application directory \(`/opt/adsb`\), edit the `.env` file using your favourite text editor. Beginners may find the editor `nano` easy to use:
+
+```shell
+nano /opt/adsb/.env
+```
+
+This file holds all of the commonly used variables \(such as our latitude, longitude and altitude\). We're going to add our OpenSky username to this file. Add the following line to the file:
+
+```shell
+RADARPLANE_UUID='YOURUUID'
+```
+
+* Replace `RADARPLANE_UUID` with the station UUID you generated earlier.
+
+For example:
+
+```shell
+RADARPLANE_UUID=00000000-0000-0000-0000-000000000000
+```
 
 ## Up-and-Running with `docker run`
 
 ```shell
+source ./.env
 docker run \
  -d \
  --rm \
  --name radarplane \
- -e TZ=YOUR_TIMEZONE \
+ -e TZ=${FEEDER_TZ} \
  -e BEASTHOST=readsb \
- -e LAT=-33.33333 \
- -e LONG=111.11111 \
+ -e LAT=${FEEDER_LAT} \
+ -e LONG=${FEEDER_LONG} \
  -e ALT=50m \
- -e SITENAME=My_Cool_ADSB_Receiver \
- -e UUID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \
+ -e SITENAME=${FEEDER_NAME} \
+ -e UUID=${RADARPLANE_UUID} \
  --tmpfs=/run:rw,nosuid,nodev,exec,relatime,size=64M,uid=1000,gid=1000 \
  ghcr.io/RadarPlane/docker-radarplane:main
 ```
@@ -73,12 +92,12 @@ An example docker compose service definition is below:
     restart: unless-stopped
     environment:
       - BEASTHOST=readsb
-      - TZ=UTC
-      - LAT=-37.7468
-      - LONG=-25.5716
+      - TZ=${FEEDER_TZ}
+      - LAT=${FEEDER_LAT}
+      - LONG=${FEEDER_LONG}
       - ALT=50m
-      - SITENAME=My_Cool_RadarPlane_Receiver
-      - UUID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+      - SITENAME=${FEEDER_NAME}
+      - UUID=${RADARPLANE_UUID}
     tmpfs:
       - /run:rw,nosuid,nodev,exec,relatime,size=64M,uid=1000,gid=1000
 ```

--- a/feeder-containers/feeding-radarvirtuel.md
+++ b/feeder-containers/feeding-radarvirtuel.md
@@ -23,13 +23,13 @@ First-time users should obtain a RadarVirtuel Feeder key. To request one, email 
 
 Inside your application directory (`/opt/adsb`), edit the `.env` file using your favorite text editor. Beginners may find the editor `nano` easy to use:
 
-```text
+```shell
 nano /opt/adsb/.env
 ```
 
 This file holds all of the commonly used variables (such as our latitude, longitude and altitude). We're going to add our RadarVirtuel Feeder Key to this file. Add the following line to the file:
 
-```text
+```shell
 RV_FEEDER_KEY=YOURFEEDERKEY
 ```
 
@@ -37,7 +37,7 @@ RV_FEEDER_KEY=YOURFEEDERKEY
 
 For example:
 
-```text
+```shell
 RV_FEEDER_KEY=xxxx:432143214473214732017432014747382140723
 ```
 

--- a/foundations/common-tasks-and-info.md
+++ b/foundations/common-tasks-and-info.md
@@ -31,7 +31,7 @@ If you want to limit the output to, for example, the last 100 lines, you can add
 
 If you would like to manually update your containers to the latest versions of their images, you can run the following commands from the application directory:
 
-```bash
+```shell
 docker compose pull
 docker compose up -d
 ```
@@ -80,7 +80,7 @@ You can inspect the container for some \(hopefully\) meaningful output from the 
 
 If you issue the command `docker inspect <container name>` \(replacing `<container name>` with the name of the container you're interested in\), you'll see lots of information about the container, including the output of the most recent run of the healthcheck script. This output is in JSON format, so with the help of the `jq` utility we can easily find our `ultrafeeder` container's most recent health information. First make sure `jq` is installed with `sudo apt install -y jq`, then we can check the `ultrafeeder` container's health with the following command:
 
-```bash
+```shell
 docker inspect ultrafeeder | jq .[0].State.Health.Log | jq .[-1].Output | awk '{gsub(/\\n/,"\n")}1'
 ```
 

--- a/foundations/deploy-dump978-usa-only.md
+++ b/foundations/deploy-dump978-usa-only.md
@@ -18,7 +18,9 @@ Every RTL-SDR dongle will have a small frequency error as it is cheaply mass pro
 
 Unplug all SDRs, leaving only the SDR to be used for 978MHz reception plugged in. Issue the following command:
 
-`docker run --rm -it --entrypoint /scripts/estimate_rtlsdr_ppm.sh --device /dev/bus/usb ghcr.io/sdr-enthusiasts/docker-readsb-protobuf:latest`
+```shell
+docker run --rm -it --entrypoint /scripts/estimate_rtlsdr_ppm.sh --device /dev/bus/usb ghcr.io/sdr-enthusiasts/docker-readsb-protobuf:latest
+```
 
 This takes about 30 minutes and will print a numerical value for estimated optimum PPM setting.
 
@@ -26,13 +28,13 @@ This takes about 30 minutes and will print a numerical value for estimated optim
 
 Inside your application directory \(`/opt/adsb`\), edit the `.env` file using your favourite text editor. Beginners may find the editor `nano` easy to use:
 
-```bash
+```shell
 nano /opt/adsb/.env
 ```
 
 This file holds all of the commonly used variables \(such as our latitude, longitude and altitude\). We're going to add more variables associated our UAT dongle.
 
-```text
+```shell
 UAT_SDR_SERIAL=978
 UAT_SDR_GAIN=<your desired gain>
 UAT_SDR_PPM=<your PPM from the step above>
@@ -44,7 +46,7 @@ UAT_SDR_PPM=<your PPM from the step above>
 
 For example:
 
-```text
+```shell
 UAT_SDR_SERIAL=978
 UAT_SDR_GAIN=autogain
 UAT_SDR_PPM=1

--- a/foundations/deploy-readsb-container.md
+++ b/foundations/deploy-readsb-container.md
@@ -9,7 +9,7 @@ description: >-
 
 In your favourite text editor, create a file named `docker-compose.yml` in your application directory \(`/opt/adsb`\) if following along verbatim.
 
-```bash
+```shell
 nano docker-compose.yml
 ```
 
@@ -62,13 +62,13 @@ The above will:
 
 Once this file is created, issue the command `docker compose up -d` to bring up the environment.
 
-```bash
+```shell
 docker compose up -d
 ```
 
 You should see the following output:
 
-```text
+```shell
 Creating network "adsb_default" with the default driver
 Creating readsb         ... done
 ```
@@ -106,6 +106,7 @@ We can view the logs for the environment with the command `docker compose logs`,
 We can see our container running with the command `docker ps`:
 
 ```text
+$ docker ps
 CONTAINER ID   IMAGE                                                   COMMAND   CREATED        STATUS                  PORTS                                       NAMES
 7b9c4be5a410   ghcr.io/sdr-enthusiasts/docker-readsb-protobuf:latest   "/init"   17 hours ago   Up 17 hours (healthy)   0.0.0.0:8080->8080/tcp, :::8080->8080/tcp   readsb
 ```
@@ -168,7 +169,7 @@ You should also be able to point your web browser at `http://docker.host.ip.addr
 
 It is possible that you won't see any planes, either with the docker command above or when pointing your web browser at the readsb container. This can have a number of root causes - a common one being that active radio transmissions in other frequency bands that are reasonably "close" to the ADS-B band are completely overwhelming your SDR at the default starting gain of 49.6. It may be necessary to lower the starting point for the autogain script to at least allow the detection of some planes in order for the script to work. So if even after a few minutes you don't see any planes at all (and no ADS-B messages in the "Performance Graphs"), you may want to try to force a lower starting gain value into the autogain algorithm. To do this, please execute the following command. You may have to try different values instead of the value of `34` suggested here:
 
-```bash
+```shell
 docker exec -it readsb sh -c "/bin/echo 34 > /run/autogain/autogain_current_value"
 docker restart readsb
 ```

--- a/foundations/deploy-ultrafeeder-container.md
+++ b/foundations/deploy-ultrafeeder-container.md
@@ -11,7 +11,7 @@ It also provides a website with a map based on tar1090, station statistics (grap
 
 In your favorite text editor, create a file named `docker-compose.yml` in your application directory (`/opt/adsb`) if you've been following along verbatim.
 
-```bash
+```shell
 nano docker-compose.yml
 ```
 
@@ -165,7 +165,7 @@ A working MLAT configuration is already provided in the example above.  See [htt
 
 Once the `docker-compose.yml` file is created, issue the command `docker compose up -d` to bring up the environment.
 
-```bash
+```shell
 docker compose up -d
 ```
 

--- a/foundations/prepare-the-project-environment.md
+++ b/foundations/prepare-the-project-environment.md
@@ -10,7 +10,7 @@ description: >-
 
 We need a directory to host our application. The name of this directory will be the name of our application. Accordingly, we prefer to use `/opt/adsb`, so our application is called "adsb":
 
-```bash
+```shell
 sudo mkdir -p -m 777 /opt/adsb
 cd /opt/adsb
 ```
@@ -19,7 +19,7 @@ cd /opt/adsb
 
 A UUID is a unique identifier that will identify you to various feeding servers. If you already have a `UUID` that was generated for the ADSBExchange service, feel free to reuse that one. If you don't have one, you can generate one by logging into your Linux machine (Raspberry Pi, etc.) and giving this command:
 
-```bash
+```shell
 cat  /proc/sys/kernel/random/uuid
 ```
 
@@ -33,7 +33,9 @@ This step is considered optional and mostly legacy/unnecessary at this point, as
 
 Unplug all SDRs, leaving only the SDR to be used for 1090MHz reception plugged in. Issue the following command:
 
-`docker run --rm -it --entrypoint /scripts/estimate_rtlsdr_ppm.sh --device /dev/bus/usb ghcr.io/sdr-enthusiasts/docker-readsb-protobuf:latest`
+```shell
+docker run --rm -it --entrypoint /scripts/estimate_rtlsdr_ppm.sh --device /dev/bus/usb ghcr.io/sdr-enthusiasts/docker-readsb-protobuf:latest
+```
 
 This takes about 30 minutes and will print a numerical value for Estimated optimum PPM setting once it completes.
 
@@ -47,13 +49,13 @@ If you decide not to include a PPM value, then you can either set `ADSB_SDR_PPM=
 
 Inside this directory, create a file named `.env` using your favourite text editor. Beginners may find the editor `nano` easy to use:
 
-```bash
+```shell
 nano /opt/adsb/.env
 ```
 
 This file will hold all of the commonly used variables \(such as our latitude, longitude, and altitude\). Initially, add the contents of the file as follows (replacing the values enclosed in `<>` with values for your environment):
 
-```text
+```shell
 FEEDER_ALT_FT=<your antenna's altitude in feet>
 FEEDER_ALT_M=<your antenna's altitude in metres>
 FEEDER_LAT=<your latitude>
@@ -84,7 +86,7 @@ FEEDER_HEYWHATSTHAT_ALTS=<desired theoretical range altitudes>
 
 For example:
 
-```text
+```shell
 FEEDER_ALT_FT=103.3465
 FEEDER_ALT_M=31.5
 FEEDER_LAT=-31.9505

--- a/setting-up-rtl-sdrs/blacklist-kernel-modules.md
+++ b/setting-up-rtl-sdrs/blacklist-kernel-modules.md
@@ -22,7 +22,7 @@ Before we can plug in our RTL-SDR dongle, we need to blacklist the kernel module
 
 To do this, we will create a blacklist file at `/etc/modprobe.d/blacklist-rtlsdr.conf` with the following command. While logged in as root, please copy and paste all lines at once, and press enter after to ensure the final line is given allowing it to run.
 
-```bash
+```shell
 sudo tee /etc/modprobe.d/blacklist-rtlsdr.conf <<EOF
 # Blacklist host from loading modules for RTL-SDRs to ensure they
 # are left available for the Docker guest.
@@ -36,7 +36,6 @@ blacklist rtl2830
 blacklist rtl2832
 blacklist rtl2832_sdr
 blacklist rtl2838
-EOF
 
 # This alone will not prevent a module being loaded if it is a
 # required or an optional dependency of another module. Some kernel
@@ -56,13 +55,15 @@ install rtl2830 /bin/false
 install rtl2832 /bin/false
 install rtl2832_sdr /bin/false
 install rtl2838 /bin/false
+
+EOF
 ```
 
 ### 2. Unload Modules
 
 Next, ensure the modules are unloaded by running the following commands:
 
-```bash
+```shell
 sudo modprobe -r dvb_core
 sudo modprobe -r dvb_usb_rtl2832u
 sudo modprobe -r dvb_usb_rtl28xxu
@@ -78,7 +79,7 @@ sudo modprobe -r rtl2838
 
 Next we rebuild the module dependency database with this command:
 
-```bash
+```shell
 sudo depmod -a
 ```
 
@@ -88,7 +89,7 @@ This may appear to initially not be doing anything, but after a short wait will 
 
 Now we need to update our boot image to ensure any references to the modules we've blacklisted are removed. (This is only needed on certain systems; feel free to ignore if this command fails.)
 
-```bash
+```shell
 sudo update-initramfs -u
 ```
 
@@ -98,7 +99,7 @@ This will take a minute or more depending on the speed of your system, and outpu
 
 Failure to do the steps above will result in the error below being spammed to the `ultrafeeder` container log.
 
-```text
+```shell
 usb_claim_interface error -6
 rtlsdr: error opening the RTLSDR device: Device or resource busy
 ```

--- a/setting-up-rtl-sdrs/re-serialise-sdrs.md
+++ b/setting-up-rtl-sdrs/re-serialise-sdrs.md
@@ -17,7 +17,7 @@ To set these serial numbers:
 
 Unplug all SDRs, leaving only the SDR to be used for 1090MHz reception plugged in. Issue the following command:
 
-```text
+```shell
 docker run --rm -it --device /dev/bus/usb --entrypoint rtl_eeprom ghcr.io/sdr-enthusiasts/docker-adsb-ultrafeeder -s 1090
 ```
 
@@ -61,7 +61,7 @@ Please replug the device for changes to take effect.
 
 Next, if you intend on receiving ADS-B UAT \(978MHz\) data with a second SDR, Unplug all SDRs, leaving only the SDR to be used for 978MHz reception plugged in. Issue the following command:
 
-```text
+```shell
 docker run --rm -it --device /dev/bus/usb --entrypoint rtl_eeprom ghcr.io/sdr-enthusiasts/docker-adsb-ultrafeeder -s 978
 ```
 

--- a/setting-up-the-host-system/preparing-your-system.md
+++ b/setting-up-the-host-system/preparing-your-system.md
@@ -89,6 +89,6 @@ denyinterfaces veth*
 
 After saving this file, restart DHCPCD
 
-```bash
+```shell
 sudo systemctl restart dhcpcd
 ```

--- a/setting-up-the-host-system/running-docker-install.md
+++ b/setting-up-the-host-system/running-docker-install.md
@@ -27,7 +27,7 @@ After running this script, your system should be ready to use `docker` and `dock
 - Feel free to inspect the script [here](https://raw.githubusercontent.com/sdr-enthusiasts/docker-install/main/docker-install.sh). You should really not blindly run other people's scripts - make sure you feel comfortable with what it does before executing it.
 - To use it, you can enter the following command:
 
-```bash
+```shell
 bash <(curl -s https://raw.githubusercontent.com/sdr-enthusiasts/docker-install/main/docker-install.sh)
 ```
 

--- a/useful-extras/auto-restart-unhealthy-containers.md
+++ b/useful-extras/auto-restart-unhealthy-containers.md
@@ -92,7 +92,7 @@ In order for us to inform`autoheal` which containers to monitor, we need to appl
 
 To tell `autoheal` to monitor your `ultrafeeder` container, you would add the following configuration directive under its service definition in your `docker-compose.yml` file:
 
-```text
+```yaml
 labels:
   - "autoheal=true"
 ```

--- a/useful-extras/managing-a-remote-station.md
+++ b/useful-extras/managing-a-remote-station.md
@@ -24,7 +24,7 @@ You should now have a unique 16 character Network ID e.g. `253ef24d630f06682`. M
 
 Join your network from your machine's command line:
 
-```bash
+```shell
 sudo zerotier-cli join xxxxxxxxxxxxxxxx
 ```
 


### PR DESCRIPTION
Fixes the blacklist where the install should be a part of the ppm testing. Adjusts code block language markup. Changes most variables that can be replaced by that of .env.