### PR TITLE
Added AvioADSB to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ These ADS-B data can be received by ~~nerds~~ enthusiasts using Software Defined
 * [The Air Traffic](https://theairtraffic.com/)
 * [HPRadar](https://skylink.hpradar.com)
 * [Fly Italy ADSB](https://flyitalyadsb.com/)
+* [AvioADSB](https://avioadsb.org/)
 
 ## For-Profit Aggregators
 


### PR DESCRIPTION
This adds AvioADSB (https://avioadsb.org/) to the community ADS‑B aggregators list. AvioADSB is a free, community-driven ADS‑B and multilateration aggregator that ingests feeds from both Mode S/ADS‑B receivers and other data sources, normalizes messages, provides a stable output stream of data. It supports standard feeder inputs, publishes near‑real‑time flight data and aircraft metadata, and provides transparent documentation for contributors and operators. Adding AvioADSB improves the guide by listing another actively maintained aggregator option for users wanting broad network coverage and MLAT support.
