### PR TITLE
Fix container name in feeding-opensky-network.md

### DIFF
--- a/feeder-containers/feeding-opensky-network.md
+++ b/feeder-containers/feeding-opensky-network.md
@@ -179,7 +179,7 @@ To explain what's going on in this addition:
   - The size of the container, by not writing changes to the underlying container; and
   - SD Card or SSD wear
 
-Once the file has been updated, issue the command `docker compose up -d` in the application directory to apply the changes and bring up the `adsbhub` container. You should see the following output:
+Once the file has been updated, issue the command `docker compose up -d` in the application directory to apply the changes and bring up the `opensky` container. You should see the following output:
 
 ```text
  ✔ Container ultrafeeder  Running


### PR DESCRIPTION
Updated container name from 'adsbhub' to 'opensky' in instructions.