### PR TITLE
chore(flake/nixpkgs): `b12141ef` -> `f13ff45a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -81,11 +81,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776548001,
-        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "lastModified": 1786106723,
+        "narHash": "sha256-zDSUbpoeo/9ZmD2+wXnzxoo1+uhL8vxc0b8yuYMKYq0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "rev": "f13ff45afd1bb73e640eaa08a7066dbed07e3238",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                          |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`62890792`](https://github.com/NixOS/nixpkgs/commit/62890792fcb6b395a3b9e4bc16eeb6ff86bb52e7) | `` python3Packages.napalm-ros: migrate to finalAttrs ``                                          |
| [`7a54b3db`](https://github.com/NixOS/nixpkgs/commit/7a54b3dbf35ef835b9226cfa36bea622b9ef5655) | `` python3Packages.napalm-hp-procurve: migrate to finalAttrs ``                                  |
| [`8ffb6f94`](https://github.com/NixOS/nixpkgs/commit/8ffb6f94aeeb95194e5fa6d923f8e3aef410a6e5) | `` subxt: 0.50.0 -> 0.50.3 ``                                                                    |
| [`00dfb29c`](https://github.com/NixOS/nixpkgs/commit/00dfb29c7c4e89fd08ae2e0ff51bebf2151de568) | `` rembg: 2.0.77 -> 2.0.78 ``                                                                    |
| [`87d1aebf`](https://github.com/NixOS/nixpkgs/commit/87d1aebfb363d755a1e6b2d8c3d5789049adf4f7) | `` timoni: 0.27.1 -> 0.29.0 ``                                                                   |
| [`b2893bce`](https://github.com/NixOS/nixpkgs/commit/b2893bced74eb363f99acd636fa2564cea60ddb1) | `` tinycdb: change license to MIT ``                                                             |
| [`b5a882d9`](https://github.com/NixOS/nixpkgs/commit/b5a882d90acb818fd3d28467f4057129ddb1b544) | `` libretro.beetle-psx: 0-unstable-2026-07-28 -> 0-unstable-2026-08-07 ``                        |
| [`19ee4422`](https://github.com/NixOS/nixpkgs/commit/19ee4422be3133e7104cf5948c467c15aaaff79f) | `` python3Packages.boto3-stubs: 1.43.65 -> 1.43.66 ``                                            |
| [`d070a051`](https://github.com/NixOS/nixpkgs/commit/d070a051c740956f1393d9e19024adad5ca6d8d9) | `` python3Packages.mypy-boto3-securityhub: 1.43.48 -> 1.43.66 ``                                 |
| [`8db3950c`](https://github.com/NixOS/nixpkgs/commit/8db3950c31c93a7b1c8a850c54bcbf96ed53c054) | `` python3Packages.mypy-boto3-sagemaker: 1.43.60 -> 1.43.66 ``                                   |
| [`af0a1fcf`](https://github.com/NixOS/nixpkgs/commit/af0a1fcfc779a156f272a6ecf52ae505e0633d73) | `` python3Packages.mypy-boto3-s3: 1.43.50 -> 1.43.66 ``                                          |
| [`c5d2be4d`](https://github.com/NixOS/nixpkgs/commit/c5d2be4da0f4e1a3a05f46eeb13de32665da095a) | `` python3Packages.mypy-boto3-mediatailor: 1.43.52 -> 1.43.66 ``                                 |
| [`c23423f5`](https://github.com/NixOS/nixpkgs/commit/c23423f5119f3bf0b27c8eebaa3f7aad80e202f8) | `` python3Packages.mypy-boto3-logs: 1.43.62 -> 1.43.66 ``                                        |
| [`984b2f9a`](https://github.com/NixOS/nixpkgs/commit/984b2f9a3b83c653f970893cd1ad4ac8376a37f9) | `` python3Packages.mypy-boto3-kafka: 1.43.60 -> 1.43.66 ``                                       |
| [`538ca345`](https://github.com/NixOS/nixpkgs/commit/538ca345f625ea9ba242164a2ad996c544a7c8cf) | `` python3Packages.mypy-boto3-gamelift: 1.43.47 -> 1.43.66 ``                                    |
| [`0e8f98a3`](https://github.com/NixOS/nixpkgs/commit/0e8f98a345233a56b22665b8a25c1ab4c763105e) | `` python3Packages.mypy-boto3-ec2: 1.43.64 -> 1.43.66 ``                                         |
| [`d9aa68a8`](https://github.com/NixOS/nixpkgs/commit/d9aa68a8ca827cf556c2582cef7ae935f94cb9fb) | `` python3Packages.mypy-boto3-devicefarm: 1.43.0 -> 1.43.66 ``                                   |
| [`79ee6d42`](https://github.com/NixOS/nixpkgs/commit/79ee6d426d7b7e831454735c22bab31b935b208c) | `` python3Packages.mypy-boto3-backup: 1.43.15 -> 1.43.66 ``                                      |
| [`fdb4dc71`](https://github.com/NixOS/nixpkgs/commit/fdb4dc7131c1ceb1a8de02c317bdff897ac058f6) | `` python3Packages.mypy-boto3-autoscaling: 1.43.38 -> 1.43.66 ``                                 |
| [`786c0f80`](https://github.com/NixOS/nixpkgs/commit/786c0f805ced7855f73c3233321c47f023a51f69) | `` python3Packages.boto3-stubs: 1.43.64 -> 1.43.65 ``                                            |
| [`b4561c75`](https://github.com/NixOS/nixpkgs/commit/b4561c75c40b1ca77294d87b55b37fae597dd675) | `` python3Packages.mypy-boto3-glue: 1.43.59 -> 1.43.65 ``                                        |
| [`080c9947`](https://github.com/NixOS/nixpkgs/commit/080c9947aa20e11b37c38591696e034ef140975c) | `` python3Packages.mypy-boto3-ecs: 1.43.43 -> 1.43.65 ``                                         |
| [`87bc0fe7`](https://github.com/NixOS/nixpkgs/commit/87bc0fe7f139de33abc1141dad25ed3a55532271) | `` python3Packages.mypy-boto3-acm-pca: 1.43.0 -> 1.43.65 ``                                      |
| [`d205052b`](https://github.com/NixOS/nixpkgs/commit/d205052ba0e435ab99e8ca83c36ff4776424f94d) | `` python3Packages.asyncmy: migrate to finalAttrs ``                                             |
| [`81540926`](https://github.com/NixOS/nixpkgs/commit/8154092638a98f95fa0c478a0f17c66a40b24c37) | `` python3Packages.pyfaup-rs: 0.4.14 -> 0.4.16 ``                                                |
| [`742fa753`](https://github.com/NixOS/nixpkgs/commit/742fa75351722cca90800c3e222bb1431df7f332) | `` python3Packages.playwrightcapture: 1.40.3 -> 1.40.5 ``                                        |
| [`0fbfbe1a`](https://github.com/NixOS/nixpkgs/commit/0fbfbe1a17443dadfc888a66b861874badc8d14b) | `` python3Packages.linode-api4: 5.46.0 -> 5.46.1 ``                                              |
| [`b05ad93b`](https://github.com/NixOS/nixpkgs/commit/b05ad93b62a0fe2bbfdf9a1159346e6dc47a0131) | `` python3Packages.llama-index-workflows: 2.22.2 -> 2.23.0 ``                                    |
| [`0b5db161`](https://github.com/NixOS/nixpkgs/commit/0b5db1614f782e32fb4649c6591e885746e9af7f) | `` python3Packages.itkwasm-downsample-wasi: 1.8.1 -> 2.0.0 ``                                    |
| [`db3f7902`](https://github.com/NixOS/nixpkgs/commit/db3f7902a6fd98a88cbbb05c98fb508656cc2758) | `` python3Packages.itkwasm-downsample-emscripten: 1.8.1 -> 2.0.0 ``                              |
| [`13e63ee0`](https://github.com/NixOS/nixpkgs/commit/13e63ee0f812228e8a4f55cacf91398dd363f90d) | `` python3Packages.itkwasm-downsample: 1.8.1 -> 2.0.0 ``                                         |
| [`40b0fa2f`](https://github.com/NixOS/nixpkgs/commit/40b0fa2fe728b6a737ac32bb352ab1fe5c1ada91) | `` python3Packages.itkwasm: 1.0b195 -> 1.0b200 ``                                                |
| [`f8738906`](https://github.com/NixOS/nixpkgs/commit/f87389069511eda4a6741822a8e5d3a784617098) | `` python3Packages.claude-agent-sdk: 0.2.130 -> 0.2.132 ``                                       |
| [`48fcf821`](https://github.com/NixOS/nixpkgs/commit/48fcf821312b78aba54fca5b489f8d26d2d38742) | `` python3Packages.boschshcpy: 0.6.6 -> 0.6.8 ``                                                 |
| [`2b249d16`](https://github.com/NixOS/nixpkgs/commit/2b249d162efaee4f028cc3cf67254d79b301b7ca) | `` python3Packages.asyncmy: 0.2.11 -> 0.2.13 ``                                                  |
| [`6065fc68`](https://github.com/NixOS/nixpkgs/commit/6065fc68df55594b4967772fa6810b59b7032606) | `` python3Packages.apify-fingerprint-datapoints: 0.13.0 -> 0.15.0 ``                             |
| [`00c639c7`](https://github.com/NixOS/nixpkgs/commit/00c639c7772913b3eddbd00831a24be6b115efde) | `` python3Packages.alibabacloud-credentials: 1.0.10 -> 1.0.11 ``                                 |
| [`36232f76`](https://github.com/NixOS/nixpkgs/commit/36232f764107bf39059300c645913406b4c11bee) | `` signal-export: 3.8.3 -> 3.9.0 ``                                                              |
| [`5d54218a`](https://github.com/NixOS/nixpkgs/commit/5d54218a116379427b9f59ba0e9a34fff0b46e39) | `` clboss: 0.16.0 -> 0.16.1 ``                                                                   |
| [`e076c124`](https://github.com/NixOS/nixpkgs/commit/e076c1248f64b7871379a12e206fdf747bc4a0cf) | `` linux_5_10: 5.10.263 -> 5.10.264 ``                                                           |
| [`b7513b76`](https://github.com/NixOS/nixpkgs/commit/b7513b7669ba5880c2a0b6ce8049161316f333fb) | `` linux_5_15: 5.15.214 -> 5.15.215 ``                                                           |
| [`7a79bdea`](https://github.com/NixOS/nixpkgs/commit/7a79bdea32ef09b8976c0988c8b6e1f2dbb20d44) | `` linux_6_1: 6.1.181 -> 6.1.182 ``                                                              |
| [`e14e0ee8`](https://github.com/NixOS/nixpkgs/commit/e14e0ee8787f4d3262fc81862127aa5470cdfc44) | `` linux_6_6: 6.6.149 -> 6.6.150 ``                                                              |
| [`a77ae285`](https://github.com/NixOS/nixpkgs/commit/a77ae285759971fd546f4faf3fa7742d6b92c58b) | `` linux_6_12: 6.12.101 -> 6.12.102 ``                                                           |
| [`81cc39b6`](https://github.com/NixOS/nixpkgs/commit/81cc39b691e058f1aca7d102a337b75ee220d851) | `` ocamlPackages.odoc: remove `cmdliner_1` override for 3.2 and newer ``                         |
| [`fbd9dccf`](https://github.com/NixOS/nixpkgs/commit/fbd9dccf1970f7e91e0db5f9575c016cb205e3b0) | `` python3Packages.iamdata: 0.1.202608061 -> 0.1.202608071 ``                                    |
| [`58fc2ba5`](https://github.com/NixOS/nixpkgs/commit/58fc2ba5a50b1f30a2dc15552a81fc6d7a31bf99) | `` warp-terminal: 0.2026.07.22.09.01.stable_01 -> 0.2026.07.29.09.05.stable_02 ``                |
| [`c8319bae`](https://github.com/NixOS/nixpkgs/commit/c8319baecf62e9e3bd736c4e7d7bdff5b63f7176) | `` ocamlPackages.mtime: 2.1.0 → 2.2.0 ``                                                         |
| [`5d2f59b9`](https://github.com/NixOS/nixpkgs/commit/5d2f59b950db6fd7abbf27fb26fa4f392008ca74) | `` vscode-extensions.anthropic.claude-code: 2.1.223 -> 2.1.224 ``                                |
| [`385c7ea5`](https://github.com/NixOS/nixpkgs/commit/385c7ea5c3127f3b05c871f986274f6317ea71d6) | `` claude-code: 2.1.223 -> 2.1.224 ``                                                            |
| [`16e56a44`](https://github.com/NixOS/nixpkgs/commit/16e56a4492492cd7a25b077d7fad728a8b2b08a0) | `` python3Packages.victron-mqtt: 2026.7.6 -> 2026.8.0 ``                                         |
| [`d05372b8`](https://github.com/NixOS/nixpkgs/commit/d05372b8671f41d2b4a0fcbb66c5929ac130f2d6) | `` xfr: 0.9.22 -> 0.9.25 ``                                                                      |
| [`e564ef40`](https://github.com/NixOS/nixpkgs/commit/e564ef40c27b7df499625a4a10842c7c24a0b30c) | `` zashboard: 3.16.0 -> 3.17.0 ``                                                                |
| [`70ac8e18`](https://github.com/NixOS/nixpkgs/commit/70ac8e18afb37d06724885b3bc9e0ecae9075304) | `` terraform-providers.oracle_oci: 8.23.0 -> 8.26.0 ``                                           |
| [`55b7cf44`](https://github.com/NixOS/nixpkgs/commit/55b7cf4435b0ec9cd462bbefdd8023ed1e124b34) | `` tideways-cli: 1.2.20 -> 1.3.0 ``                                                              |
| [`d6f41963`](https://github.com/NixOS/nixpkgs/commit/d6f41963bc933a23c5bf9d36d2bc42c6feb54192) | `` rufin: 0.12.0 -> 0.12.5 ``                                                                    |
| [`e6f4ac0c`](https://github.com/NixOS/nixpkgs/commit/e6f4ac0c31ba3c1676dd39cdcdbd190bce5ed1ce) | `` iptvnator: init at 0.22.0 ``                                                                  |
| [`0a525169`](https://github.com/NixOS/nixpkgs/commit/0a525169606082dd8c273a5abc56d1dc3b0b94b9) | `` fcitx5-lotus: 3.4.0 -> 3.4.1 ``                                                               |
| [`f125c27f`](https://github.com/NixOS/nixpkgs/commit/f125c27f41a67ba0b9ccee9589537bbdf47a389b) | `` allure: 2.44.1 -> 2.45.0 ``                                                                   |
| [`b6c273d4`](https://github.com/NixOS/nixpkgs/commit/b6c273d4adf9ff4b5f347e052292d62810c99cae) | `` gleam: 1.18.0 -> 1.18.1 ``                                                                    |
| [`0c0b2a47`](https://github.com/NixOS/nixpkgs/commit/0c0b2a47c2ed77dc4546ab0a4b0530b1c15a617e) | `` Revert "rPackages: strip dynamic libraries" ``                                                |
| [`3ca1d4ba`](https://github.com/NixOS/nixpkgs/commit/3ca1d4bac8087153ac75328136a30352afe6f340) | `` python3Packages.msgraph-sdk: 1.60.0 -> 1.61.0 ``                                              |
| [`706864e2`](https://github.com/NixOS/nixpkgs/commit/706864e22c461830ed94a7b27d856ae4d18c921f) | `` google-chrome: 151.0.7922.75 -> 151.0.7922.108 ``                                             |
| [`a76bb41f`](https://github.com/NixOS/nixpkgs/commit/a76bb41fae127ccf1884c45b18fcaaa8969493db) | `` chromedriver: reintroduce `x86_64-darwin` to update script ``                                 |
| [`46efe546`](https://github.com/NixOS/nixpkgs/commit/46efe546abf7478a72c45119b3dff472aa37ab8f) | `` libretro.bluemsx: 0-unstable-2026-07-27 -> 0-unstable-2026-07-29 ``                           |
| [`88733642`](https://github.com/NixOS/nixpkgs/commit/88733642763ff4e76ced2d5864b903411ee3a72e) | `` git-graph: 0.7.0 -> 0.8.0 ``                                                                  |
| [`3c11cb86`](https://github.com/NixOS/nixpkgs/commit/3c11cb86355347f7c26c93cb03e2b074e398794d) | `` jj-vine: 0.5.3 -> 0.5.4 ``                                                                    |
| [`b71f6354`](https://github.com/NixOS/nixpkgs/commit/b71f6354b67df555fc4506de0b63d1453de5a755) | `` sony-dump: fix version scheme ``                                                              |
| [`20d28ea1`](https://github.com/NixOS/nixpkgs/commit/20d28ea167be5c2b936fd2d787893ba2190c3d94) | `` pg-schema-diff: 1.0.8 -> 1.0.9 ``                                                             |
| [`10ff09a8`](https://github.com/NixOS/nixpkgs/commit/10ff09a813051f81d2f9b65e709560b504e4c073) | `` multica-cli: 0.4.13 -> 0.4.20 ``                                                              |
| [`fdc69b2e`](https://github.com/NixOS/nixpkgs/commit/fdc69b2eec913674bccf279589629041da1a38ca) | `` itgmaniaPackages.digital-dance: 1.1.5-unstable-2026-07-28 -> 1.1.5-unstable-2026-08-05 ``     |
| [`7a4e3d70`](https://github.com/NixOS/nixpkgs/commit/7a4e3d70fa5ac63357ccb732a660aa87e92d8fa3) | `` pocket-id: re-enable a test, now it mocks networking ``                                       |
| [`161f845f`](https://github.com/NixOS/nixpkgs/commit/161f845f456f45638e169de9db95a6cfb830073b) | `` python3Packages.djvulibre-python: rename from djvulibre-python, fix metadata ``               |
| [`503efe5d`](https://github.com/NixOS/nixpkgs/commit/503efe5d6609ef91458a800193fddcc057d073fd) | `` vimPlugins.codediff-nvim: 2.53.1 -> 2.66.0 ``                                                 |
| [`29f206a6`](https://github.com/NixOS/nixpkgs/commit/29f206a67f773501f662f9319356e389f7bee40e) | `` postgresqlPackages.timescaledb: update postgresql19 broken check version ``                   |
| [`9e539b4b`](https://github.com/NixOS/nixpkgs/commit/9e539b4be5e6b292eb56175aa427ac57353666bd) | `` codipack: 3.1.1 -> 3.1.2 ``                                                                   |
| [`6353cafd`](https://github.com/NixOS/nixpkgs/commit/6353cafd49022d0aef72dc44ce8c7e691bdb2797) | `` prl-tools: 26.4.0-57513 -> 26.4.1-57516 ``                                                    |
| [`6c73d88f`](https://github.com/NixOS/nixpkgs/commit/6c73d88ff3fdb22252a468fab81e3547b3b11e42) | `` python314Packages.iterm2: 2.13 -> 2.20, clean up ``                                           |
| [`36b46d0a`](https://github.com/NixOS/nixpkgs/commit/36b46d0ac7450356e0bc2cd101f68035e85bd6e0) | `` pocket-id: fix some test failing after upstream hid some test files behind tags ``            |
| [`223e6a16`](https://github.com/NixOS/nixpkgs/commit/223e6a1653c0b4881b6218044c6e515a1e707133) | `` hoppscotch: 26.5.0-0 -> 26.7.0-0 ``                                                           |
| [`6ff19026`](https://github.com/NixOS/nixpkgs/commit/6ff190260e2cc33bb2f1088b988ab4e3e50e7623) | `` python3Packages.paddlepaddle: fix build with cudaSupport ``                                   |
| [`df3408a5`](https://github.com/NixOS/nixpkgs/commit/df3408a5bc645d307cdaa5fc83e978d2a395ff3b) | `` chromium,chromedriver: 151.0.7922.75 -> 151.0.7922.108 ``                                     |
| [`856abb86`](https://github.com/NixOS/nixpkgs/commit/856abb86a1fb54e7acb3fb69d0f27799cdef2d12) | `` top-level: correct python3Packages aliases ``                                                 |
| [`0d7c17e5`](https://github.com/NixOS/nixpkgs/commit/0d7c17e595a0c7ee2bde181e3d4059e3139cb7d7) | `` flyctl: 0.4.75 -> 0.4.79 ``                                                                   |
| [`e9577a1a`](https://github.com/NixOS/nixpkgs/commit/e9577a1a923f60781b03beb7bc69c9c509e61d86) | `` nightlight: 0.3.1 -> 1.0.0 ``                                                                 |
| [`54f6123c`](https://github.com/NixOS/nixpkgs/commit/54f6123c51b53347a754106d1228e43b2905b53c) | `` dnsproxy: 0.83.1 -> 0.83.2 ``                                                                 |
| [`3dcaa869`](https://github.com/NixOS/nixpkgs/commit/3dcaa8690f9faff30c6657c5df6a3a6053ce5ea6) | `` trezor-suite: 26.7.2 -> 26.7.4 ``                                                             |
| [`b52480ef`](https://github.com/NixOS/nixpkgs/commit/b52480ef599be3313d7d083550666393a4e2475f) | `` postgresqlPackages.timescaledb-apache: 2.29.0 -> 2.29.1 ``                                    |
| [`2a390287`](https://github.com/NixOS/nixpkgs/commit/2a3902873874f8fcd44dd0ba2ff9f38c22dad43c) | `` python3Packages.napalm-hp-procurve: fix build; wrong pname ``                                 |
| [`b303f1af`](https://github.com/NixOS/nixpkgs/commit/b303f1aff2cf6dca7b9a4624df13fec7eb8e640b) | `` python3Packages.napalm-ros: fix build ``                                                      |
| [`5a3c319c`](https://github.com/NixOS/nixpkgs/commit/5a3c319cac3130ac30d170a7179ef80d8f3fb5c0) | `` stakk: 1.17.1 -> 1.17.2 ``                                                                    |
| [`742b4ac5`](https://github.com/NixOS/nixpkgs/commit/742b4ac59bef0a816f18e92ef7c0fee602a245c1) | `` qui: 1.24.0 -> 1.25.0 ``                                                                      |
| [`0b0412ae`](https://github.com/NixOS/nixpkgs/commit/0b0412ae023ead76e74f39de4ee9c1968f60b157) | `` pijul: 1.0.0-beta.18 -> 1.0.0-beta.21 ``                                                      |
| [`b96db959`](https://github.com/NixOS/nixpkgs/commit/b96db9592e7cad73fb02b18f506aec32f7fd0729) | `` meters-lv2: 0.9.20 -> 0.9.28, drop gtk2 dependency ``                                         |
| [`3e3ac058`](https://github.com/NixOS/nixpkgs/commit/3e3ac05838d89850bc49c24590272353739c46e2) | `` libretro.fbneo: 0-unstable-2026-07-28 -> 0-unstable-2026-08-06 ``                             |
| [`e863c353`](https://github.com/NixOS/nixpkgs/commit/e863c353a4b208c5568f06cd23e81017d7337864) | `` linux_5_10: 5.10.262 -> 5.10.263 ``                                                           |
| [`066d6f32`](https://github.com/NixOS/nixpkgs/commit/066d6f32cd393d7dfc86b7371a9614285ae7ff05) | `` linux_5_15: 5.15.213 -> 5.15.214 ``                                                           |
| [`fb41260a`](https://github.com/NixOS/nixpkgs/commit/fb41260a3987d1e51af6b24da5d15624c3b61f0d) | `` linux_6_1: 6.1.180 -> 6.1.181 ``                                                              |
| [`b7f99cc1`](https://github.com/NixOS/nixpkgs/commit/b7f99cc10ab8f7644fe972e63053e74ec4889d55) | `` linux_6_6: 6.6.148 -> 6.6.149 ``                                                              |
| [`8541058c`](https://github.com/NixOS/nixpkgs/commit/8541058c2638629af82dcad9c0805ee755d32cdd) | `` linux_6_18: 6.18.42 -> 6.18.43 ``                                                             |
| [`ed600574`](https://github.com/NixOS/nixpkgs/commit/ed600574cefc88fbfac4ec6f30f6d50774510857) | `` linux_7_1: 7.1.6 -> 7.1.7 ``                                                                  |
| [`28ae351a`](https://github.com/NixOS/nixpkgs/commit/28ae351a91199300b4543987322d8740373054ed) | `` diskwatch: 0.1.5 -> 0.1.6 ``                                                                  |
| [`e701ff05`](https://github.com/NixOS/nixpkgs/commit/e701ff054bbfdcbd8bfefd4c53c6ab87edad2dd7) | `` Reapply "nixos/nixpkgs.config: make use of the module defined in config.nix" ``               |
| [`3e3a8a80`](https://github.com/NixOS/nixpkgs/commit/3e3a8a802555e842332e5f6b627f53b4a0e76209) | `` openssl_1_1: drop ``                                                                          |
| [`092fb765`](https://github.com/NixOS/nixpkgs/commit/092fb76539cf08edf0ee03ad58d710bb3c69812d) | `` ntfy-sh: 2.26.3 -> 2.27.0 ``                                                                  |
| [`b234d5ff`](https://github.com/NixOS/nixpkgs/commit/b234d5ff7c6422ed11b29bc71bda2844055963b0) | `` worktrunk: 0.68.0 -> 0.71.0 ``                                                                |
| [`2baf04ea`](https://github.com/NixOS/nixpkgs/commit/2baf04ea3d0bd0fc8c1fda35f7df2f96e55a8c4f) | `` pi-coding-agent: 0.83.0 -> 0.84.0 ``                                                          |
| [`139b2345`](https://github.com/NixOS/nixpkgs/commit/139b23453ff65a1d05855b61c09d3f8c55d21f75) | `` fetchtastic: 0.11.1 -> 0.11.2 ``                                                              |
| [`c79be8db`](https://github.com/NixOS/nixpkgs/commit/c79be8db71e46c8e29b2bb5012c667ec33738ffd) | `` python3Packages.types-tqdm: 4.69.0.20260728 -> 4.70.0.20260805 ``                             |
| [`635abf92`](https://github.com/NixOS/nixpkgs/commit/635abf9204924da87dafc56d8ac1995961a24db5) | `` libretro.hatari: 0-unstable-2026-07-28 -> 0-unstable-2026-07-31 ``                            |
| [`05ebe0fe`](https://github.com/NixOS/nixpkgs/commit/05ebe0fe669a254c9822e8a1680c574d6097d0e8) | `` everforest-gtk-theme: reinit with no gtk-engine-murrine dependency ``                         |
| [`209fbf30`](https://github.com/NixOS/nixpkgs/commit/209fbf30b5199db0355a91db29fd63065a6e3413) | `` python3Packages.roadtx: 1.22.0 -> 1.22.1 ``                                                   |
| [`971ffdbf`](https://github.com/NixOS/nixpkgs/commit/971ffdbf042c8eb76ef7fe5e54c70fc530ba1f1b) | `` opnborg: 0.1.81 -> 0.1.132 ``                                                                 |
| [`e1a6de54`](https://github.com/NixOS/nixpkgs/commit/e1a6de54954202484fa4a4b64b1df1103cef6c4e) | `` libretro.puae: 0-unstable-2026-06-03 -> 0-unstable-2026-07-30 ``                              |
| [`b59f2063`](https://github.com/NixOS/nixpkgs/commit/b59f2063d76e2aba7086652ee6f3e801b23ebd53) | `` ungoogled-chromium: 151.0.7922.71-1 -> 151.0.7922.75-1 ``                                     |
| [`9664cdb3`](https://github.com/NixOS/nixpkgs/commit/9664cdb37ea10839d018f0b3d3da5587ba55c8e7) | `` nixos/auditd: adjust defaults according to upstream ``                                        |
| [`83967855`](https://github.com/NixOS/nixpkgs/commit/839678550f757bf68de9f217dadf62e7ecda9abe) | `` aardvark-dns: 2.0.0 -> 2.1.0 ``                                                               |
| [`4f613560`](https://github.com/NixOS/nixpkgs/commit/4f61356013b920af425b62856957c3c7f5a8efa0) | `` ghostfolio: 3.35.0 -> 3.43.0 ``                                                               |
| [`9781c292`](https://github.com/NixOS/nixpkgs/commit/9781c2925dce88a527fd65f4fb110f77e8d71656) | `` python3Packages.hier-config: 3.6.2 -> 4.0.0b1 ``                                              |
| [`e86ea75b`](https://github.com/NixOS/nixpkgs/commit/e86ea75bc3b825d44d4344df56205b678eb5edaa) | `` mastodon: 4.6.4 -> 4.6.5 ``                                                                   |
| [`5c3b278f`](https://github.com/NixOS/nixpkgs/commit/5c3b278f3e1994caa451e7a5dc980698780f76f5) | `` nono: 0.68.0 -> 0.71.0 ``                                                                     |
| [`c369295c`](https://github.com/NixOS/nixpkgs/commit/c369295cf44ef50aa48067e8f51a035a7914ccc3) | `` home-assistant.python3Packages.pytest-homeassistant-custom-component: 0.13.353 -> 0.13.354 `` |
| [`2973c4cd`](https://github.com/NixOS/nixpkgs/commit/2973c4cd4738bb1675aeaa5fadce1969b1dc534d) | `` python3Packages.homeassistant-stubs: 2026.7.4 -> 2026.8.0 ``                                  |
| [`0ae30516`](https://github.com/NixOS/nixpkgs/commit/0ae30516d8f44893ef7968071a316f77075ea7b7) | `` home-assistant-custom-components.gtfs_realtime: update snapshots ``                           |
| [`ed79e893`](https://github.com/NixOS/nixpkgs/commit/ed79e893320038829b8dc99aa97c4d7b8d792729) | `` home-assistant: patch constant name in ezviz component ``                                     |
| [`83c8bae3`](https://github.com/NixOS/nixpkgs/commit/83c8bae3e9b8114fa3b75771d5493b074ffbdcdf) | `` home-assistant-custom-components.midea_ac_lan: drop ``                                        |
| [`1fd7e8b7`](https://github.com/NixOS/nixpkgs/commit/1fd7e8b708764b5c9ee4a8fbc26b20902de3deab) | `` python3Packages.thingqconnect: fix csr generation ``                                          |
| [`0f9306ad`](https://github.com/NixOS/nixpkgs/commit/0f9306ad07fc211b4314c4f6eb9ee40134e601c4) | `` home-assistant-custom-components.llm_intents: 1.8.3 -> 1.9.0 ``                               |
| [`dbd67341`](https://github.com/NixOS/nixpkgs/commit/dbd67341133b62c78c7a401487653c668065b122) | `` python3Packages.typedmonarchmoney: drop ``                                                    |
| [`5178448a`](https://github.com/NixOS/nixpkgs/commit/5178448aebd0e5aaaad221c891c97a0c4bc80700) | `` python3Packages.mypermobil: drop ``                                                           |
| [`a4a0fc81`](https://github.com/NixOS/nixpkgs/commit/a4a0fc81281360aaa6ed672462a645e8290dbb05) | `` python3Packages.pyvizio: drop ``                                                              |
| [`40aef661`](https://github.com/NixOS/nixpkgs/commit/40aef6615930a808537809b26e78c31f54f0af0a) | `` home-assistant-custom-lovelace-modules.mushroom: 5.2.1 -> 5.2.2 ``                            |
| [`9f7a64d3`](https://github.com/NixOS/nixpkgs/commit/9f7a64d3380dd35c27d0cdec83bde11b5f8d0627) | `` home-assistant-custom-lovelace-modules.multiple-entity-row: 4.7.1 -> 4.9.0 ``                 |
| [`1928a82e`](https://github.com/NixOS/nixpkgs/commit/1928a82e7f81d96413fd1a087f17eee4762ba6ea) | `` home-assistant-custom-lovelace-modules.material-you-utilities: 2.1.21 -> 2.1.23 ``            |
| [`971d45aa`](https://github.com/NixOS/nixpkgs/commit/971d45aa1a0ed41fac8d4fcc44e32b127606a583) | `` home-assistant-custom-lovelace-modules.kiosk-mode: 14.0.1 -> 14.0.2 ``                        |
| [`0c59e275`](https://github.com/NixOS/nixpkgs/commit/0c59e27562f654a01e1fd285aab6845cfff8f489) | `` home-assistant-custom-lovelace-modules.custom-sidebar: 16.1.0 -> 17.0.0 ``                    |
| [`903d0e1e`](https://github.com/NixOS/nixpkgs/commit/903d0e1ec65c9b0f1508559849a76e8158edcb6f) | `` home-assistant-custom-lovelace-modules.custom-brand-icons: 2026.07.3 -> 2026.08.0 ``          |
| [`5cb6f913`](https://github.com/NixOS/nixpkgs/commit/5cb6f9131a9294be40eab604b7154f1e6dbf1a58) | `` home-assistant-custom-lovelace-modules.auto-entities: 2.6.0 -> 2.6.1 ``                       |
| [`78a46d8a`](https://github.com/NixOS/nixpkgs/commit/78a46d8abf7d1a8be1d8af2f13bf29c900bd00af) | `` home-assistant-custom-components.solax_modbus: 2026.07.1 -> 2026.08.2 ``                      |
| [`149252fe`](https://github.com/NixOS/nixpkgs/commit/149252fe26defed00317c6883561c51bcb634a7f) | `` home-assistant-custom-components.powercalc: 1.23.2 -> 1.24.0 ``                               |
| [`30dd7022`](https://github.com/NixOS/nixpkgs/commit/30dd702252877d1f7f0b90a9a8b897c1c5387cf2) | `` home-assistant-custom-components.plant: 2026.7.2 -> 2026.8.0 ``                               |
| [`dcc8476d`](https://github.com/NixOS/nixpkgs/commit/dcc8476de46e1f51a5d07dc845c92657d2ab9074) | `` home-assistant-custom-components.opensprinkler: 1.5.6 -> 1.6.1 ``                             |
| [`e9c2d3ad`](https://github.com/NixOS/nixpkgs/commit/e9c2d3ad823244aa7d6d89e45b39511dd79d8222) | `` python3Packages.pyopensprinkler: 0.7.17 -> 0.7.19 ``                                          |
| [`4e101331`](https://github.com/NixOS/nixpkgs/commit/4e10133160458a258bd2f36098cc977f473811ea) | `` home-assistant-custom-components.octopus_energy: 18.3.3 -> 19.0.0 ``                          |
| [`e2d53eb9`](https://github.com/NixOS/nixpkgs/commit/e2d53eb9cf40d93f48bf188ef1a56f2eedf4283b) | `` home-assistant-custom-components.miraie: 1.1.7 -> 1.1.8 ``                                    |
| [`4d7a23aa`](https://github.com/NixOS/nixpkgs/commit/4d7a23aaff024511ff841a63ba5c32ae30eb7b6a) | `` python3Packages.miraie-ac: 1.1.1 -> 1.1.2 ``                                                  |
| [`0ff60f07`](https://github.com/NixOS/nixpkgs/commit/0ff60f074959ceae20141e1b8bcdeb657b75de74) | `` home-assistant-custom-components.midea-air-appliances-lan: 0.9.6 -> 0.9.7 ``                  |
| [`710b779e`](https://github.com/NixOS/nixpkgs/commit/710b779e9eeaa91649f681ee757c0c6b13fc4430) | `` python3Packages.midea-beautiful-air: 0.10.5 -> 0.10.7 ``                                      |
| [`01b099fc`](https://github.com/NixOS/nixpkgs/commit/01b099fc1ecb992c23f0e073a15e96d8559947aa) | `` home-assistant-custom-components.midea_ac_lan: 0.6.12 -> 0.7.1 ``                             |
| [`0764ddf7`](https://github.com/NixOS/nixpkgs/commit/0764ddf759780170c6950d8053efda3928f01ba3) | `` home-assistant-custom-components.emporia_vue: 0.12.2 -> 0.12.3 ``                             |
| [`39a89569`](https://github.com/NixOS/nixpkgs/commit/39a89569df036942b4c619c79c1eb07415c5d940) | `` home-assistant-custom-components.ecoflow_ble: 1.0.2 -> 1.0.3 ``                               |
| [`bda98ae5`](https://github.com/NixOS/nixpkgs/commit/bda98ae567a5fee25248b27ff2c8b7539a298f6a) | `` home-assistant-custom-components.dreo: 1.11.0 -> 1.11.1 ``                                    |
| [`4be64339`](https://github.com/NixOS/nixpkgs/commit/4be643390b86b984f7d1466b57d86a29099eca02) | `` home-assistant-custom-components.cover_time_based: 4.10.0 -> 4.11.0 ``                        |
| [`cb66a1b2`](https://github.com/NixOS/nixpkgs/commit/cb66a1b23ee9d23bbeb08040e512cc28f54a6642) | `` home-assistant-custom-components.browser-mod: 3.1.0 -> 3.2.0 ``                               |
| [`1a756518`](https://github.com/NixOS/nixpkgs/commit/1a756518c01e87bc05dbf6c133877c633452b89a) | `` home-assistant-custom-components.battery_notes: 3.5.1 -> 3.5.2 ``                             |
| [`0a33360f`](https://github.com/NixOS/nixpkgs/commit/0a33360f71e46f594701aad1044abf0483d334ef) | `` home-assistant.python3Packages.pytest-homeassistant-custom-component: 0.13.348 -> 0.13.353 `` |
| [`25686ed0`](https://github.com/NixOS/nixpkgs/commit/25686ed04f500c6ad2a7b9a14b095e0a86d0b3dd) | `` python3Packages.matrix-nio: 0.25.2 -> 0.26.0 ``                                               |
| [`763bc674`](https://github.com/NixOS/nixpkgs/commit/763bc674a8fb52cadf00369737ab05241dfbfa5a) | `` python3Packages.apischema: enable on Python 3.14 with disabled tests ``                       |
| [`76e00393`](https://github.com/NixOS/nixpkgs/commit/76e003937a7aa04e2618dd92d81d239127dd05fe) | `` python3Packages.pydrawise: 2026.6.0 -> 2026.7.0 ``                                            |
| [`2aae0d9b`](https://github.com/NixOS/nixpkgs/commit/2aae0d9bf9b8681f4cd3dae5b79aab3be5848234) | `` home-assistant: 2026.7.4 -> 2026.8.0 ``                                                       |
| [`102d1219`](https://github.com/NixOS/nixpkgs/commit/102d121917695729d39f9c0440b0f85f2bb6e04a) | `` super-productivity: 18.16.0 -> 18.17.0 ``                                                     |
| [`3316d036`](https://github.com/NixOS/nixpkgs/commit/3316d03606ea76aca3f0ae6e45ed8213258b9874) | `` mpvScripts.uosc: 5.12.0 -> 5.13.0 ``                                                          |
| [`8c1063e4`](https://github.com/NixOS/nixpkgs/commit/8c1063e4097c6180fd6a42b42913c27d19dcf830) | `` ocamlPackages.ninja_utils: 1.0.0 -> 2.0.0 ``                                                  |
| [`081aa145`](https://github.com/NixOS/nixpkgs/commit/081aa145fa99de82e48377a6bd6e488b808bda60) | `` vacask: init at 0.3.3 ``                                                                      |
| [`ed2be103`](https://github.com/NixOS/nixpkgs/commit/ed2be10381d83f977928c06313d2e9d9bfffa4aa) | `` python3Packages.bleak-smlight: init at 1.1.1 ``                                               |
| [`917c16cd`](https://github.com/NixOS/nixpkgs/commit/917c16cd39a83de597f63b00facee4cf7396701c) | `` python3Packages.zha-quirks: 2.1.1 -> 2.2.0 ``                                                 |
| [`99914adf`](https://github.com/NixOS/nixpkgs/commit/99914adf86422a1f4db8a381841a76b6b2b9eb29) | `` python3Packages.zha: 2.0.1 -> 2.1.0 ``                                                        |
| [`5987c2f6`](https://github.com/NixOS/nixpkgs/commit/5987c2f65c8d08ffc2ccf0a2206cc38aa84052a0) | `` python3Packages.bellows: 0.49.2 -> 1.0.0 ``                                                   |
| [`31bb2796`](https://github.com/NixOS/nixpkgs/commit/31bb279634092cbf3fc656b368d2c99b1a165a19) | `` python3Packages.zigpy-ziggurat: 1.0.1 -> 1.1.1 ``                                             |
| [`27ffcdcb`](https://github.com/NixOS/nixpkgs/commit/27ffcdcb55931995ea0eeb32f9794063d88dca4d) | `` python3Packages.aiospinel: init at 1.2.0 ``                                                   |
| [`7fe9ace5`](https://github.com/NixOS/nixpkgs/commit/7fe9ace582b514db0d5e92c60d424a7e6ddea8b9) | `` python3Packages.zigpy-deconz: 0.25.5 -> 1.0.0 ``                                              |
| [`6c086d7a`](https://github.com/NixOS/nixpkgs/commit/6c086d7ab78a1af4465a8e57249a9fca168dda19) | `` python3Packages.zigpy: 2.0.1 -> 2.1.0 ``                                                      |
| [`cf1e69e4`](https://github.com/NixOS/nixpkgs/commit/cf1e69e45121e8e21f47ecd36c6bb8f4e7703fe6) | `` python3Packages.yalexs: 9.2.7 -> 9.2.10 ``                                                    |
| [`2a56da23`](https://github.com/NixOS/nixpkgs/commit/2a56da2386eea3083cf16d7d3ec13fff86492a98) | `` python3Packages.wiim: 0.1.5 -> 0.1.6 ``                                                       |
| [`fe65b388`](https://github.com/NixOS/nixpkgs/commit/fe65b38833110d753ec42765092e7580c6516f64) | `` python3Packages.tuya-device-sharing-sdk: 0.2.13 -> 0.2.14 ``                                  |
| [`9a78990a`](https://github.com/NixOS/nixpkgs/commit/9a78990ae7f784f3138ec7f800f2fe0233b5c908) | `` python3Packages.solaredge-web: 0.2.0 -> 0.3.0 ``                                              |
| [`67fadce8`](https://github.com/NixOS/nixpkgs/commit/67fadce816209c927ff40d57164a2e4b044a3cdc) | `` python3Packages.reolink-aio: 0.21.4 -> 0.21.8 ``                                              |
| [`af59576d`](https://github.com/NixOS/nixpkgs/commit/af59576ddb676922da25223d80387af08bf361e9) | `` python3Packages.pyvicare: 2.60.2 -> 2.61.0 ``                                                 |
| [`ed779956`](https://github.com/NixOS/nixpkgs/commit/ed77995611bac60c39408d65ed5f70b98906b577) | `` python3Packages.pytrydan: 1.0.2 -> 1.0.4 ``                                                   |
| [`9dd753e6`](https://github.com/NixOS/nixpkgs/commit/9dd753e6f2321f6cfac500710ca442d23543b2ce) | `` python3Packages.python-izone: 1.2.10 -> 1.3.9 ``                                              |
| [`82f6a911`](https://github.com/NixOS/nixpkgs/commit/82f6a91164b570f9f82c54dd0a3ef6a22c3812ee) | `` python3Packages.python-homewizard-energy: 10.1.0 -> 10.2.0 ``                                 |
| [`798cf66d`](https://github.com/NixOS/nixpkgs/commit/798cf66de4c405aa88289d530bf7deb52644ae14) | `` python3Packages.pystiebeleltron: 0.3.2 -> 0.6.2 ``                                            |
| [`300fa1af`](https://github.com/NixOS/nixpkgs/commit/300fa1af77014017061c118c6a03bf05feedc1c7) | `` python3Packages.python-aidot: 0.3.53 -> 0.3.56 ``                                             |
| [`32054a29`](https://github.com/NixOS/nixpkgs/commit/32054a2987808fecdf854fe6e1502fb9d3bae423) | `` python3Packages.pysignalclirestapi: 0.3.24 -> 0.3.25 ``                                       |
| [`aebdea9b`](https://github.com/NixOS/nixpkgs/commit/aebdea9bf89714ae5f5651f3458d18b9883bd28e) | `` python3Packages.pymonoprice: 0.5 -> 0.6.1 ``                                                  |
| [`d6188321`](https://github.com/NixOS/nixpkgs/commit/d6188321c4882b3cdcaa8378baf5bc52abd5e44f) | `` python3Packages.pyschlage: 2025.9.0 -> 2026.7.0 ``                                            |
| [`580641ad`](https://github.com/NixOS/nixpkgs/commit/580641ad73e8b84733f717c0e47356d9c0b8b946) | `` python3Packages.pysaunum: 0.6.0 -> 0.7.0 ``                                                   |
| [`6bcac135`](https://github.com/NixOS/nixpkgs/commit/6bcac1356bfcf00cc5be76d9f2899b1952156d3a) | `` python3Packages.pynintendoparental: 2.4.0.1 -> 2.5.0 ``                                       |
| [`727d2af1`](https://github.com/NixOS/nixpkgs/commit/727d2af1cee4951b8060b9ed884e5d16804a3e82) | `` python3Packages.pynintendoauth: 1.0.2 -> 1.0.3 ``                                             |
| [`784e7a9a`](https://github.com/NixOS/nixpkgs/commit/784e7a9a40472cfef02732484c3bca3980838540) | `` python3Packages.pyliebherrhomeapi: 0.4.1 -> 0.5.1 ``                                          |
| [`fec5d810`](https://github.com/NixOS/nixpkgs/commit/fec5d8109c4c6a44c2eeea7de3d28193428b17b8) | `` python3Packages.pyintesishome: 1.8.8 -> 2.2.0 ``                                              |
| [`64178ec0`](https://github.com/NixOS/nixpkgs/commit/64178ec03fe11735535233ef6999ad410664a7bc) | `` python3Packages.pyhomee: 1.4.2 -> 1.4.3 ``                                                    |
| [`04b7d42c`](https://github.com/NixOS/nixpkgs/commit/04b7d42cb60992165b63f1624a3594f7a23cf437) | `` python3Packages.pyatmo: 9.4.0 -> 9.6.0 ``                                                     |
| [`cc36f645`](https://github.com/NixOS/nixpkgs/commit/cc36f645ccf9e6535d4c8995878ac172ad5d70f5) | `` python3Packages.pyairobotrest: 0.3.0 -> 0.4.0 ``                                              |
| [`c32053e4`](https://github.com/NixOS/nixpkgs/commit/c32053e4724f833b374cfc417ecc0f8ff997bc22) | `` python3Packages.py-opendisplay: 7.2.3 -> 7.15.0 ``                                            |
| [`16d6ddd9`](https://github.com/NixOS/nixpkgs/commit/16d6ddd9671ab89ecedfe31fb60bd11a951741d8) | `` python3Packages.silabs-ble-ota: init at 0.1.0 ``                                              |
| [`5da12fe8`](https://github.com/NixOS/nixpkgs/commit/5da12fe83d51b582e61fb8711222953e3f80a4a8) | `` python3Packages.nrf-ota: init at 0.4.0 ``                                                     |
| [`fc46dfca`](https://github.com/NixOS/nixpkgs/commit/fc46dfcadd26ca1d863b705fd34165c67d10df48) | `` python3Packages.pyairnow: 1.3.1 -> 1.4.1 ``                                                   |
| [`19819de6`](https://github.com/NixOS/nixpkgs/commit/19819de61a2c21e5079083b1fa756510dc43328c) | `` python3Packages.oralb-ble: 1.1.0 -> 1.1.3 ``                                                  |
| [`f7017a24`](https://github.com/NixOS/nixpkgs/commit/f7017a24672c0d9538dce25430d4264faa12d405) | `` python3Packages.music-assistant-client: 1.3.6 -> 1.4.3 ``                                     |
| [`bb755971`](https://github.com/NixOS/nixpkgs/commit/bb7559718ba8716e5e73efaf83be56e2be63c066) | `` python3Packages.music-assistant-models: 1.1.139 -> 1.1.152 ``                                 |
| [`9feb7356`](https://github.com/NixOS/nixpkgs/commit/9feb7356753fc4723fb1456ede9e04a03b56486c) | `` python3Packages.meteo-lt-pkg: 0.2.4 -> 0.7.3 ``                                               |
| [`a777b71e`](https://github.com/NixOS/nixpkgs/commit/a777b71e6237ed7377c0fb5d543e82ce21bc7d06) | `` python3Packages.midea-local: 6.8.0 -> 6.11.1 ``                                               |
| [`d5e34008`](https://github.com/NixOS/nixpkgs/commit/d5e3400872f12b17eafada253fb55627db27b498) | `` python3Packages.matter-python-client: 0.8.0 -> 1.3.3 ``                                       |
| [`f85ab000`](https://github.com/NixOS/nixpkgs/commit/f85ab000ca4524e07fa81ec8bf16657014ef8cf4) | `` python3Packages.librouteros: 3.4.1 -> 4.1.1 ``                                                |
| [`b959f5da`](https://github.com/NixOS/nixpkgs/commit/b959f5daa9ff225ef1c761442efbda1b08b46e33) | `` python3Packages.knx-telegram-store: 0.4.0 -> 0.11.2 ``                                        |
| [`8e25ae37`](https://github.com/NixOS/nixpkgs/commit/8e25ae37121591924d4513395cdb1a4dd7f90d90) | `` python3Packages.knx-frontend: 2026.7.23.145751 -> 2026.8.2.133643 ``                          |
| [`651a5507`](https://github.com/NixOS/nixpkgs/commit/651a5507cfb3fee03efd7315bb4e83d14b3fd4d7) | `` python3Packages.infrared-protocols: 6.3.1 -> 9.0.0 ``                                         |
| [`2ca52a42`](https://github.com/NixOS/nixpkgs/commit/2ca52a429924bec3d9e613d78308b22d6c5e151a) | `` python3Packages.idasen-ha: 2.7.0 -> 3.0.1 ``                                                  |
| [`c41acf63`](https://github.com/NixOS/nixpkgs/commit/c41acf6319cbd908b141c547ca1355ecbddfb726) | `` home-assistant.intents: 2026.6.24 -> 2026.7.30 ``                                             |
| [`7c067747`](https://github.com/NixOS/nixpkgs/commit/7c0677472dda81f165cefd02510f09054870cd4f) | `` python3Packages.ical: 13.3.0 -> 14.0.1 ``                                                     |
| [`18de7ef0`](https://github.com/NixOS/nixpkgs/commit/18de7ef0eee548635cb5929c954ce659ddaaa15a) | `` python3Packages.holidays: 0.100 -> 0.102 ``                                                   |
| [`94117456`](https://github.com/NixOS/nixpkgs/commit/9411745672c5bbf2bb9861fef63ff0b61b24cd89) | `` python3Packages.ha-iotawattpy: 0.1.2 -> 0.2.1 ``                                              |
| [`9d7da5dd`](https://github.com/NixOS/nixpkgs/commit/9d7da5ddc4d3cccb073b38aefd4efdc71e983c17) | `` python3Packages.hassil: 3.8.0 -> 3.11.0 ``                                                    |
| [`b82729fe`](https://github.com/NixOS/nixpkgs/commit/b82729fed91ec100fbbe45358f44c73b3d3b9ddc) | `` python3Packages.gcal-sync: 9.0.0 -> 9.1.0 ``                                                  |
| [`6ed0112c`](https://github.com/NixOS/nixpkgs/commit/6ed0112c7a55e4bf2bb76286998d2764f2f6203f) | `` python3Packages.evohome-async: 1.2.0 -> 2.0.1 ``                                              |
| [`dafd7ca6`](https://github.com/NixOS/nixpkgs/commit/dafd7ca6ff1d69f4a259f82e0c7beaec325dfc69) | `` python3Packages.blinkpy: 0.25.7 -> 0.25.9 ``                                                  |
| [`82a1080a`](https://github.com/NixOS/nixpkgs/commit/82a1080a4c3b9915f354c6db554547eb7d38bf78) | `` python3Packages.esphome-dashboard-api: 1.3.0 -> 1.4.0 ``                                      |
| [`e94af332`](https://github.com/NixOS/nixpkgs/commit/e94af33293241e66454575a77d63c92d7355f812) | `` python3Packages.bleak-retry-connector: 4.6.1 -> 4.6.3 ``                                      |
| [`364483d7`](https://github.com/NixOS/nixpkgs/commit/364483d71dfe3bd153e135b3d8c0218aa02ee8f4) | `` python3Packages.async-upnp-client: 0.46.2 -> 0.48.0 ``                                        |
| [`54db53b7`](https://github.com/NixOS/nixpkgs/commit/54db53b78c44c39281301e98b702a86f5f72d9d3) | `` python3Packages.aiowebostv: 0.7.5 -> 0.9.0 ``                                                 |
| [`f7b54c0e`](https://github.com/NixOS/nixpkgs/commit/f7b54c0e2759c702c79cf7b06c29a221afe7a477) | `` python3Packages.aiopvapi: 3.3.0 -> 3.4.0 ``                                                   |
| [`e5ae2cab`](https://github.com/NixOS/nixpkgs/commit/e5ae2cab938f8d5125fed9111b4225d56d3327ae) | `` python3Packages.aiomealie: 1.2.4 -> 2.0.0 ``                                                  |
| [`ddcd3fe1`](https://github.com/NixOS/nixpkgs/commit/ddcd3fe126bf96da915f4400697c472ce5bc3e98) | `` python3Packages.aiohasupervisor: 0.5.0 -> 0.6.0 ``                                            |
| [`67884639`](https://github.com/NixOS/nixpkgs/commit/678846395bfa70ee53c467c4c98ab43a1e4b8355) | `` python3Packages.aiohue: 4.8.1 -> 4.9.0 ``                                                     |
| [`5901d018`](https://github.com/NixOS/nixpkgs/commit/5901d018bd79b01933811c6eb1243b3b724836b8) | `` python3Packages.aiohomekit: 3.2.20 -> 4.0.0 ``                                                |
| [`d1bb2c89`](https://github.com/NixOS/nixpkgs/commit/d1bb2c891f9a8e34960ffe0aba43e3fc2fc8773a) | `` python3Packages.aioesphomeapi: 45.3.1 -> 45.6.1 ``                                            |
| [`6b671d5d`](https://github.com/NixOS/nixpkgs/commit/6b671d5df940873e6c4ec839293926f25b0406a7) | `` python3Packages.aioacaia: 0.1.18 -> 0.2.1 ``                                                  |
| [`da894e35`](https://github.com/NixOS/nixpkgs/commit/da894e35f577d36b7b040e1628ee8f2ad6112d38) | `` python3Packages.afsapi: 1.0.1 -> 1.0.2 ``                                                     |
| [`fa55389a`](https://github.com/NixOS/nixpkgs/commit/fa55389a16c4f488eddcf189e6bf5fb4f31c9e1c) | `` home-assistant: fix ruff lint in helper scripts ``                                            |
| [`cded4f5c`](https://github.com/NixOS/nixpkgs/commit/cded4f5cd4bcf57c7dfcae3b91e349273dcfad90) | `` ocamlPackages.httpcats: 0.2.1 → 0.3.1 ``                                                      |
| [`7c35011b`](https://github.com/NixOS/nixpkgs/commit/7c35011b1a7afb2c9ed2fef0e0cac4946d54dc21) | `` pinnacle: pin libdisplay-info version for config ``                                           |
| [`cf140204`](https://github.com/NixOS/nixpkgs/commit/cf140204da377c4f3959bfb09822ab08acec99b7) | `` strictdoc: add dadada as to maintainers ``                                                    |
| [`827c1a8f`](https://github.com/NixOS/nixpkgs/commit/827c1a8ff9070659632ae883c79b3279afef4fe1) | `` ocamlPackages.miou: 0.5.5 → 0.8.0 ``                                                          |
| [`91568319`](https://github.com/NixOS/nixpkgs/commit/915683198e33a4b4b4141b11550614b09933defa) | `` python3Packages.notus-scanner: 22.7.2 -> 23.0.0 ``                                            |
| [`551a5bf4`](https://github.com/NixOS/nixpkgs/commit/551a5bf48d54b375a20980665aa4bafad3852367) | `` postgresqlPackages.plpgsql_check: 2.10.3 -> 2.10.4 ``                                         |
| [`e2e1f228`](https://github.com/NixOS/nixpkgs/commit/e2e1f228d72747042fdbfa66ddec4be56ec4b904) | `` python3Packages.hstspreload: 2026.7.1 -> 2026.8.1 ``                                          |
| [`0ae7c35c`](https://github.com/NixOS/nixpkgs/commit/0ae7c35c289a4286ba2f56685eac7b6048d9afc2) | `` feather: fix build with zxing-cpp 3 ``                                                        |
| [`aa927429`](https://github.com/NixOS/nixpkgs/commit/aa9274296329af61ee9feabb3bb78478cd43b1b9) | `` lasuite-meet: 1.25.0 -> 1.25.2 ``                                                             |
| [`f25cbfe7`](https://github.com/NixOS/nixpkgs/commit/f25cbfe7e55b4d5f97756a6e40fc488ae253924d) | `` tombi: 1.2.6 -> 1.2.7 ``                                                                      |
| [`387d6c8e`](https://github.com/NixOS/nixpkgs/commit/387d6c8e99af91e8d9cf3c08e003e611d5d36877) | `` tidal-hifi: 7.0.1 -> 8.1.1 ``                                                                 |
| [`61f9f51a`](https://github.com/NixOS/nixpkgs/commit/61f9f51aec74e8c902bf43960af6ab55c232b1fd) | `` wezterm: 0-unstable-2026-07-16 -> 0-unstable-2026-08-05 ``                                    |
| [`68aef01d`](https://github.com/NixOS/nixpkgs/commit/68aef01d2e55a47f301afb3f89d5b2f8fa4783ea) | `` fastnetmon-advanced: add netali to maintainers ``                                             |
| [`0ee925d8`](https://github.com/NixOS/nixpkgs/commit/0ee925d82e6f6fafea40c76ee6fe4d3059dff092) | `` python3Packages.pylance: 9.0.0 -> 9.0.1 ``                                                    |
| [`5b0eec5a`](https://github.com/NixOS/nixpkgs/commit/5b0eec5ae26b4a534e83fe83659a200c92a23149) | `` openvaf: init at 24.0.1 ``                                                                    |
| [`7cc1fda1`](https://github.com/NixOS/nixpkgs/commit/7cc1fda1f6007cdfc2cc76c6659cd9b53cd7ba5b) | `` fastnetmon-advanced: 2.0.380 -> 2.0.383 ``                                                    |
| [`12ae4e84`](https://github.com/NixOS/nixpkgs/commit/12ae4e84e17b7b05ad4d656e5283197202ada441) | `` gitify: 7.0.1 -> 7.2.0 ``                                                                     |
| [`51dfe697`](https://github.com/NixOS/nixpkgs/commit/51dfe6971d8dcc1356201a6dc523682eb4e9a734) | `` tlsanalyzer: 0.3.0 -> 0.4.1 ``                                                                |
| [`2c0a6a78`](https://github.com/NixOS/nixpkgs/commit/2c0a6a781cc59ed5f962261fa528242af686780c) | `` bitrise: 2.42.1 -> 2.42.2 ``                                                                  |
| [`b3896169`](https://github.com/NixOS/nixpkgs/commit/b389616989c0ceb0dc1554d3a941041acc3e6ab0) | `` renovate: enable structuredAttrs, strictDeps ``                                               |
| [`dfa52526`](https://github.com/NixOS/nixpkgs/commit/dfa5252629b13304a520f112b3f683a62c68b38d) | `` renovate: 43.214.1 -> 44.13.1 ``                                                              |
| [`c2b8bfe9`](https://github.com/NixOS/nixpkgs/commit/c2b8bfe97bef2b3be3f6ddd3ec9be3e4ca8180ad) | `` ostui: 1.3.5 -> 1.3.6 ``                                                                      |
| [`1556ee02`](https://github.com/NixOS/nixpkgs/commit/1556ee020ad27e824a297283aea395d7fce9f49f) | `` seaweedfs: 4.40 -> 4.41 ``                                                                    |
| [`36219c35`](https://github.com/NixOS/nixpkgs/commit/36219c35b7294d9acc981f2a738c87fce6ad168e) | `` zennotes-desktop: 2.22.1 -> 2.23.0 ``                                                         |
| [`824985e0`](https://github.com/NixOS/nixpkgs/commit/824985e03b20a914114f83617f8d009cbb1b1f74) | `` {python3Package,}padne: init at 0.3 ``                                                        |
| [`57e00fef`](https://github.com/NixOS/nixpkgs/commit/57e00fef202a59add56b557ad5474fa93fa19df5) | `` python3Packages.python-qube-heatpump: 1.12.0 -> 1.13.0 ``                                     |
| [`641b0cfa`](https://github.com/NixOS/nixpkgs/commit/641b0cfaf80270df8739d8512f5798e3a5455b35) | `` terraform-providers.newrelic_newrelic: 3.95.2 -> 3.96.0 ``                                    |
| [`4badb6d0`](https://github.com/NixOS/nixpkgs/commit/4badb6d03a1f417b435955fb3bed000509f75e98) | `` mago: 1.45.0 -> 1.46.0 ``                                                                     |
| [`608368b7`](https://github.com/NixOS/nixpkgs/commit/608368b7459ef6a5de0004d938f6c16cb350a382) | `` python3Packages.sphinx-codeautolink: 0.18.1 -> 0.19.0 ``                                      |
| [`5447e41b`](https://github.com/NixOS/nixpkgs/commit/5447e41b602eb2fd5079b416fdfb574b6d85c458) | `` python3Packages.google-cloud-access-context-manager: 0.6.0 -> 0.6.1 ``                        |
| [`7bf731dc`](https://github.com/NixOS/nixpkgs/commit/7bf731dcb2e31c8ac4b542fa2d27e57ffd1bd8b5) | `` python3Packages.pyanglianwater: 3.2.4 -> 3.3.0 ``                                             |
| [`8d4f651a`](https://github.com/NixOS/nixpkgs/commit/8d4f651ad9135fca33553526afa3bfaa3bcfc29a) | `` tuicr: 0.20.0 -> 0.21.0 ``                                                                    |
| [`1c110986`](https://github.com/NixOS/nixpkgs/commit/1c11098689d91dea7fe2fbbab4df82f8ce67e454) | `` python3Packages.tencentcloud-sdk-python: 3.1.150 -> 3.1.151 ``                                |
| [`9161ec9e`](https://github.com/NixOS/nixpkgs/commit/9161ec9e3b2214bba78fb34cf6b476b0dfb71bf5) | `` python3Packages.iamdata: 0.1.202608051 -> 0.1.202608061 ``                                    |
| [`18569113`](https://github.com/NixOS/nixpkgs/commit/185691139a2e7cbe2566b95edb7fd994be1f7345) | `` terraform-providers.opentelekomcloud_opentelekomcloud: 1.37.2 -> 1.37.3 ``                    |
| [`9da4ca67`](https://github.com/NixOS/nixpkgs/commit/9da4ca67aedf4f8c3007b6123a9ae63115c3c3a3) | `` home-assistant-custom-components.browser-mod: 3.1.0 -> 3.2.0 ``                               |
| [`f91f0faf`](https://github.com/NixOS/nixpkgs/commit/f91f0faf9848dad3b029305c59951093ba1c09bf) | `` awakened-poe-trade: 3.29.102 -> 3.29.103 ``                                                   |
| [`f28f524e`](https://github.com/NixOS/nixpkgs/commit/f28f524e919c3175506d5d26751b3c8d56c9467f) | `` pana: 0.23.14 -> 0.23.16 ``                                                                   |
| [`a65f6616`](https://github.com/NixOS/nixpkgs/commit/a65f661680daf6c6814fcaf8b6fc780e2a2c5da9) | `` fence: 0.1.64 -> 0.1.66 ``                                                                    |
| [`0da9ddb5`](https://github.com/NixOS/nixpkgs/commit/0da9ddb59fd8421d8c280085f4de02cf0aa9364d) | `` vscode-extensions.anthropic.claude-code: 2.1.222 -> 2.1.223 ``                                |
| [`2f388e38`](https://github.com/NixOS/nixpkgs/commit/2f388e38b124530c4eac5e1766885c8391d84d82) | `` claude-code: 2.1.222 -> 2.1.223 ``                                                            |
| [`6d471f6c`](https://github.com/NixOS/nixpkgs/commit/6d471f6c751735afd8c07e93f77e495ebd8ae3aa) | `` dblab: 0.47.0 -> 0.47.3 ``                                                                    |
| [`d23f6757`](https://github.com/NixOS/nixpkgs/commit/d23f67571fdd898b6912c11058bbd8850f7fe2a0) | `` uutils-findutils: 0.9.0 -> 0.10.0 ``                                                          |
| [`34ba98f1`](https://github.com/NixOS/nixpkgs/commit/34ba98f1f34840d1ddb9b1da81346a40890fa020) | `` vermouth: 1.9.7 -> 2.0.1 ``                                                                   |
| [`415fa870`](https://github.com/NixOS/nixpkgs/commit/415fa87056f6e41aec0a913fc70e7e2e309bbf14) | `` mesa: 26.1.6 -> 26.2.0 ``                                                                     |

*... and 5095 more commits (truncated)*